### PR TITLE
Move the code over to flex.

### DIFF
--- a/annotator.yaml
+++ b/annotator.yaml
@@ -1,17 +1,3 @@
 runtime: go
-api_version: go1
+env: flex
 service: annotator
-
-handlers:
-- url: /.*
-  script: _go_app
-
-
-skip_files:
-  - ^(.*/)?#.*#$
-  - ^(.*/)?.*~$
-  - ^(.*/)?.*\.py[co]$
-  - ^(.*/)?.*/RCS/.*$
-  - ^(.*/)?\..*$
-  - proto/
-  - ^#.*#$

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -11,10 +11,8 @@ import (
 	"github.com/m-lab/annotation-service/metrics"
 )
 
-func init() {
-	// TODO: load tables here
+func SetupHandlers() {
 	http.HandleFunc("/annotate", Annotate)
-	metrics.SetupPrometheus()
 }
 
 // Annotate looks up IP address and returns geodata.

--- a/start.go
+++ b/start.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/m-lab/annotation-service/handler"
+	"github.com/m-lab/annotation-service/metrics"
+)
+
+func main() {
+	handler.SetupHandlers()
+	metrics.SetupPrometheus()
+	// TODO setup data structures here
+	// TODO(JM) setup pubsub here
+	log.Print("Listening on port 8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
It now runs in the app engine flexible environment, at least for the purposes of returning the canned response. I don't know if other code will break when run in the flexible environment, but we can't really know until it is called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/19)
<!-- Reviewable:end -->
