### PR TITLE
Made prometheus work in ae flex.

### DIFF
--- a/annotator.yaml
+++ b/annotator.yaml
@@ -1,3 +1,20 @@
 runtime: go
 env: flex
 service: annotator
+
+resources:
+  cpu: 2
+  # Instances support between [(cpu * 0.9) - 0.4, (cpu * 6.5) - 0.4]
+  # Actual memory available is exposed via GAE_MEMORY_MB environment variable.
+  memory_gb: 8
+
+# Note: add a public port for GCE auto discovery by prometheus.
+# TODO(dev): are any values redundant or irrelevant?
+network:
+  instance_tag: annotator
+  name: default
+  # Forward port 9090 on the GCE instance address to the same port in the
+  # container address. Only forward TCP traffic.
+  # Note: the default AppEngine container port 8080 cannot be forwarded.
+  forwarded_ports:
+    - 9090/tcp

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net/http"
+	_ "net/http/pprof"
 
 	"github.com/m-lab/annotation-service/handler"
 	"github.com/m-lab/annotation-service/metrics"


### PR DESCRIPTION
This PR creates the port forwarding rules for port 9090, changes prometheus metrics to be exported on port 9090, increased the resources allocated to each instance so that they actually run, and exported the pprof profile on /debug/pprof on both ports 8080 and 9090.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/33)
<!-- Reviewable:end -->
