### PR TITLE
Support for tags -- use ETL style conditions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,5 +105,5 @@ deploy:
   skip_cleanup: true
   on:
     repo: m-lab/annotation-service
-    tag: true
+    all_branches: true
     condition: "$TRAVIS_TAG == prod-*"


### PR DESCRIPTION
This change fixes support for tags.

The "tag" directive is a typo. And, the correct "tags" directive does not support `condition` expressions.

So, this PR updates the production deploy to use etl-style conditions, which means the on: condition will be evaluated on all branches instead of only tags, but only match when TRAVIS_TAG is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/65)
<!-- Reviewable:end -->
