### PR TITLE
use region-code not region-name

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -211,12 +211,12 @@ func ConvertIPNodeToGeoData(ipNode parser.IPNode, locationNodes []parser.Locatio
 		Geo: &annotation.GeolocationIP{
 			Continent_code: locNode.ContinentCode,
 			Country_code:   locNode.CountryCode,
-			Country_code3:  "",
+			Country_code3:  "", // missing from geoLite2 ?
 			Country_name:   locNode.CountryName,
-			Region:         locNode.RegionName,
+			Region:         locNode.RegionCode,
 			Metro_code:     locNode.MetroCode,
 			City:           locNode.CityName,
-			Area_code:      0, //locNode.AreaCode,
+			Area_code:      0, // new geoLite2 does not have area code.
 			Postal_code:    ipNode.PostalCode,
 			Latitude:       ipNode.Latitude,
 			Longitude:      ipNode.Longitude,

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -24,7 +24,7 @@ func TestAnnotate(t *testing.T) {
 		time string
 		res  string
 	}{
-		{"1.4.128.0", "625600", `{"Geo":{"region":"Maine","city":"Not A Real City","postal_code":"10583","latitude":0,"longitude":0},"ASN":{}}`},
+		{"1.4.128.0", "625600", `{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583","latitude":0,"longitude":0},"ASN":{}}`},
 		{"This will be an error.", "1000", "Invalid request"},
 	}
 	handler.CurrentGeoDataset = &parser.GeoDataset{
@@ -46,7 +46,7 @@ func TestAnnotate(t *testing.T) {
 		},
 		LocationNodes: []parser.LocationNode{
 			{
-				CityName: "Not A Real City", RegionName: "Maine",
+				CityName: "Not A Real City", RegionCode: "ME",
 			},
 		},
 	}
@@ -172,7 +172,7 @@ func TestBatchAnnotate(t *testing.T) {
 		{
 			body: `[{"ip": "127.0.0.1", "timestamp": "2017-08-25T13:31:12.149678161-04:00"},
                                {"ip": "2620:0:1003:1008:5179:57e3:3c75:1886", "timestamp": "2017-08-25T13:31:12.149678161-04:00"}]`,
-			res: `{"127.0.0.1ov94o0":{"Geo":{"region":"Maine","city":"Not A Real City","postal_code":"10583","latitude":0,"longitude":0},"ASN":{}},"2620:0:1003:1008:5179:57e3:3c75:1886ov94o0":{"Geo":{"region":"Maine","city":"Not A Real City","postal_code":"10583","latitude":0,"longitude":0},"ASN":{}}}`,
+			res: `{"127.0.0.1ov94o0":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583","latitude":0,"longitude":0},"ASN":{}},"2620:0:1003:1008:5179:57e3:3c75:1886ov94o0":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583","latitude":0,"longitude":0},"ASN":{}}}`,
 		},
 	}
 	handler.CurrentGeoDataset = &parser.GeoDataset{
@@ -194,7 +194,7 @@ func TestBatchAnnotate(t *testing.T) {
 		},
 		LocationNodes: []parser.LocationNode{
 			{
-				CityName: "Not A Real City", RegionName: "Maine",
+				CityName: "Not A Real City", RegionCode: "ME",
 			},
 		},
 	}
@@ -249,7 +249,7 @@ func TestGetMetadataForSingleIP(t *testing.T) {
 	for _, test := range tests {
 		res := handler.GetMetadataForSingleIP(test.req)
 		if !reflect.DeepEqual(res, test.res) {
-			t.Errorf("Expected %s, got %s", test.res, res)
+			t.Errorf("Expected %v, got %v", test.res, res)
 		}
 	}
 }
@@ -262,9 +262,9 @@ func TestConvertIPNodeToGeoData(t *testing.T) {
 	}{
 		{
 			node: parser.IPNode{LocationIndex: 0, PostalCode: "10583"},
-			locs: []parser.LocationNode{{CityName: "Not A Real City", RegionName: "Maine"}},
+			locs: []parser.LocationNode{{CityName: "Not A Real City", RegionCode: "ME"}},
 			res: &annotation.GeoData{
-				Geo: &annotation.GeolocationIP{City: "Not A Real City", Postal_code: "10583", Region: "Maine"},
+				Geo: &annotation.GeolocationIP{City: "Not A Real City", Postal_code: "10583", Region: "ME"},
 				ASN: &annotation.IPASNData{}},
 		},
 		{
@@ -278,7 +278,7 @@ func TestConvertIPNodeToGeoData(t *testing.T) {
 	for _, test := range tests {
 		res := handler.ConvertIPNodeToGeoData(test.node, test.locs)
 		if !reflect.DeepEqual(res, test.res) {
-			t.Errorf("Expected %s, got %s", test.res, res)
+			t.Errorf("Expected %v, got %v", test.res, res)
 		}
 	}
 }


### PR DESCRIPTION
Legacy system used region_code, not region_name.  This should provide consistent behavior.

TODO: we should probably return the full data, and let the consumer pull out what they need.  See issue #67

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/68)
<!-- Reviewable:end -->
