### PR TITLE
Json fixes

### DIFF
--- a/common/geo.go
+++ b/common/geo.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"time"
+)
+
+// The GeolocationIP struct contains all the information needed for the
+// geolocation data that will be inserted into big query. The fiels are
+// capitalized for exporting, although the originals in the DB schema
+// are not.
+type GeolocationIP struct {
+	Continent_code string  `json:"continent_code,,omitempty"` // Gives a shorthand for the continent
+	Country_code   string  `json:"country_code,,omitempty"`   // Gives a shorthand for the country
+	Country_code3  string  `json:"country_code3,,omitempty"`  // Gives a shorthand for the country
+	Country_name   string  `json:"country_name,,omitempty"`   // Name of the country
+	Region         string  `json:"region,,omitempty"`         // Region or State within the country
+	Metro_code     int64   `json:"metro_code,,omitempty"`     // Metro code within the country
+	City           string  `json:"city,,omitempty"`           // City within the region
+	Area_code      int64   `json:"area_code,,omitempty"`      // Area code, similar to metro code
+	Postal_code    string  `json:"postal_code,,omitempty"`    // Postal code, again similar to metro
+	Latitude       float64 `json:"latitude,,omitempty"`       // Latitude
+	Longitude      float64 `json:"longitude,,omitempty"`      // Longitude
+}
+
+// The struct that will hold the IP/ASN data when it gets added to the
+// schema. Currently empty and unused.
+type IPASNData struct{}
+
+// The main struct for the geo metadata, which holds pointers to the
+// Geolocation data and the IP/ASN data. This is what we parse the JSON
+// response from the annotator into.
+type GeoData struct {
+	Geo *GeolocationIP // Holds the geolocation data
+	ASN *IPASNData     // Holds the IP/ASN data
+}
+
+// The RequestData schema is the schema for the json that we will send
+// down the pipe to the annotation service.
+type RequestData struct {
+	IP        string    // Holds the IP from an incoming request
+	IPFormat  int       // Holds the ip format, 4 or 6
+	Timestamp time.Time // Holds the timestamp from an incoming request
+}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/m-lab/annotation-service/common"
 	"github.com/m-lab/annotation-service/metrics"
 	"github.com/m-lab/annotation-service/parser"
 	"github.com/m-lab/annotation-service/search"
-	"github.com/m-lab/etl/annotation"
 )
 
 func init() {
@@ -78,7 +78,7 @@ func Annotate(w http.ResponseWriter, r *http.Request) {
 // ValidateAndParse takes a request and validates the URL parameters,
 // verifying that it has a valid ip address and time. Then, it uses
 // that to construct a RequestData struct and returns the pointer.
-func ValidateAndParse(r *http.Request) (*annotation.RequestData, error) {
+func ValidateAndParse(r *http.Request) (*common.RequestData, error) {
 	query := r.URL.Query()
 
 	time_milli, err := strconv.ParseInt(query.Get("since_epoch"), 10, 64)
@@ -93,9 +93,9 @@ func ValidateAndParse(r *http.Request) (*annotation.RequestData, error) {
 		return nil, errors.New("invalid IP address")
 	}
 	if newIP.To4() != nil {
-		return &annotation.RequestData{ip, 4, time.Unix(time_milli, 0)}, nil
+		return &common.RequestData{ip, 4, time.Unix(time_milli, 0)}, nil
 	}
-	return &annotation.RequestData{ip, 6, time.Unix(time_milli, 0)}, nil
+	return &common.RequestData{ip, 6, time.Unix(time_milli, 0)}, nil
 }
 
 // BatchResponse is the response type for batch requests.  It is converted to
@@ -103,19 +103,19 @@ func ValidateAndParse(r *http.Request) (*annotation.RequestData, error) {
 type BatchResponse struct {
 	Version string
 	Date    time.Time
-	Results map[string]*annotation.GeoData
+	Results map[string]*common.GeoData
 }
 
 // NewBatchResponse returns a new response struct.
 // Caller must properly initialize the version and date strings.
 // TODO - pass in the data source and use to populate the version/date.
 func NewBatchResponse(size int) *BatchResponse {
-	responseMap := make(map[string]*annotation.GeoData, size)
+	responseMap := make(map[string]*common.GeoData, size)
 	return &BatchResponse{"", time.Time{}, responseMap}
 }
 
 // BatchAnnotate is a URL handler that expects the body of the request
-// to contain a JSON encoded slice of annotation.RequestDatas. It will
+// to contain a JSON encoded slice of common.RequestDatas. It will
 // look up all the ip addresses and bundle them into a map of metadata
 // structs (with the keys being the ip concatenated with the base 36
 // encoded timestamp) and send them back, again JSON encoded.
@@ -138,7 +138,7 @@ func BatchAnnotate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	responseMap := make(map[string]*annotation.GeoData)
+	responseMap := make(map[string]*common.GeoData)
 	for _, data := range dataSlice {
 		responseMap[data.IP+strconv.FormatInt(data.Timestamp.Unix(), encodingBase)] = GetMetadataForSingleIP(&data)
 	}
@@ -153,16 +153,16 @@ func BatchAnnotate(w http.ResponseWriter, r *http.Request) {
 
 // BatchValidateAndParse will take a reader (likely the body of a
 // request) containing the JSON encoded array of
-// annotation.RequestDatas. It will then validate that json and use it to
-// construct a slice of annotation.RequestDatas, which it will return. If
+// common.RequestDatas. It will then validate that json and use it to
+// construct a slice of common.RequestDatas, which it will return. If
 // it encounters an error, then it will return nil and that error.
-func BatchValidateAndParse(source io.Reader) ([]annotation.RequestData, error) {
+func BatchValidateAndParse(source io.Reader) ([]common.RequestData, error) {
 	jsonBuffer, err := ioutil.ReadAll(source)
-	validatedData := []annotation.RequestData{}
+	validatedData := []common.RequestData{}
 	if err != nil {
 		return nil, err
 	}
-	uncheckedData := []annotation.RequestData{}
+	uncheckedData := []common.RequestData{}
 
 	err = json.Unmarshal(jsonBuffer, &uncheckedData)
 	if err != nil {
@@ -177,16 +177,16 @@ func BatchValidateAndParse(source io.Reader) ([]annotation.RequestData, error) {
 		if newIP.To4() != nil {
 			ipType = 4
 		}
-		validatedData = append(validatedData, annotation.RequestData{data.IP, ipType, data.Timestamp})
+		validatedData = append(validatedData, common.RequestData{data.IP, ipType, data.Timestamp})
 	}
 	return validatedData, nil
 }
 
-// GetMetadataForSingleIP takes a pointer to a annotation.RequestData
+// GetMetadataForSingleIP takes a pointer to a common.RequestData
 // struct and will use it to fetch the appropriate associated
 // metadata, returning a pointer. It is gaurenteed to return a non-nil
 // pointer, even if it cannot find the appropriate metadata.
-func GetMetadataForSingleIP(request *annotation.RequestData) *annotation.GeoData {
+func GetMetadataForSingleIP(request *common.RequestData) *common.GeoData {
 	metrics.Metrics_totalLookups.Inc()
 	if CurrentGeoDataset == nil {
 		// TODO: Block until the value is not nil
@@ -222,13 +222,13 @@ func GetMetadataForSingleIP(request *annotation.RequestData) *annotation.GeoData
 // ConvertIPNodeToGeoData takes a parser.IPNode, plus a list of
 // locationNodes. It will then use that data to fill in a GeoData
 // struct and return its pointer.
-func ConvertIPNodeToGeoData(ipNode parser.IPNode, locationNodes []parser.LocationNode) *annotation.GeoData {
+func ConvertIPNodeToGeoData(ipNode parser.IPNode, locationNodes []parser.LocationNode) *common.GeoData {
 	locNode := parser.LocationNode{}
 	if ipNode.LocationIndex >= 0 {
 		locNode = locationNodes[ipNode.LocationIndex]
 	}
-	return &annotation.GeoData{
-		Geo: &annotation.GeolocationIP{
+	return &common.GeoData{
+		Geo: &common.GeolocationIP{
 			Continent_code: locNode.ContinentCode,
 			Country_code:   locNode.CountryCode,
 			Country_code3:  "", // missing from geoLite2 ?
@@ -241,7 +241,7 @@ func ConvertIPNodeToGeoData(ipNode parser.IPNode, locationNodes []parser.Locatio
 			Latitude:       ipNode.Latitude,
 			Longitude:      ipNode.Longitude,
 		},
-		ASN: &annotation.IPASNData{},
+		ASN: &common.IPASNData{},
 	}
 
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -72,13 +72,13 @@ func TestValidateAndParse(t *testing.T) {
 			req: httptest.NewRequest("GET",
 				"http://example.com/annotate?ip_addr=127.0.0.1&since_epoch=fail", nil),
 			res: nil,
-			err: errors.New("Invalid time"),
+			err: errors.New("invalid time"),
 		},
 		{
 			req: httptest.NewRequest("GET",
 				"http://example.com/annotate?ip_addr=fail&since_epoch=10", nil),
 			res: nil,
-			err: errors.New("Invalid IP address"),
+			err: errors.New("invalid IP address"),
 		},
 		{
 			req: httptest.NewRequest("GET",

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -24,7 +24,7 @@ func TestAnnotate(t *testing.T) {
 		time string
 		res  string
 	}{
-		{"1.4.128.0", "625600", `{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583","latitude":0,"longitude":0},"ASN":{}}`},
+		{"1.4.128.0", "625600", `{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583","latitude":42.1,"longitude":-73.1},"ASN":{}}`},
 		{"This will be an error.", "1000", "Invalid request"},
 	}
 	handler.CurrentGeoDataset = &parser.GeoDataset{
@@ -34,6 +34,8 @@ func TestAnnotate(t *testing.T) {
 				IPAddressHigh: net.IPv4(255, 255, 255, 255),
 				LocationIndex: 0,
 				PostalCode:    "10583",
+				Latitude:      42.1,
+				Longitude:     -73.1,
 			},
 		},
 		IP6Nodes: []parser.IPNode{
@@ -42,6 +44,8 @@ func TestAnnotate(t *testing.T) {
 				IPAddressHigh: net.IP{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
 				LocationIndex: 0,
 				PostalCode:    "10583",
+				Latitude:      42.1,
+				Longitude:     -73.1,
 			},
 		},
 		LocationNodes: []parser.LocationNode{
@@ -172,7 +176,7 @@ func TestBatchAnnotate(t *testing.T) {
 		{
 			body: `[{"ip": "127.0.0.1", "timestamp": "2017-08-25T13:31:12.149678161-04:00"},
                                {"ip": "2620:0:1003:1008:5179:57e3:3c75:1886", "timestamp": "2017-08-25T13:31:12.149678161-04:00"}]`,
-			res: `{"127.0.0.1ov94o0":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583","latitude":0,"longitude":0},"ASN":{}},"2620:0:1003:1008:5179:57e3:3c75:1886ov94o0":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583","latitude":0,"longitude":0},"ASN":{}}}`,
+			res: `{"127.0.0.1ov94o0":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583"},"ASN":{}},"2620:0:1003:1008:5179:57e3:3c75:1886ov94o0":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583"},"ASN":{}}}`,
 		},
 	}
 	handler.CurrentGeoDataset = &parser.GeoDataset{

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -168,15 +168,19 @@ func TestBatchAnnotate(t *testing.T) {
 	tests := []struct {
 		body string
 		res  string
+		alt  string // Alternate valid result
 	}{
 		{
 			body: "{",
 			res:  "Invalid Request!",
+			alt:  "",
 		},
 		{
 			body: `[{"ip": "127.0.0.1", "timestamp": "2017-08-25T13:31:12.149678161-04:00"},
                                {"ip": "2620:0:1003:1008:5179:57e3:3c75:1886", "timestamp": "2017-08-25T13:31:12.149678161-04:00"}]`,
 			res: `{"127.0.0.1ov94o0":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583"},"ASN":{}},"2620:0:1003:1008:5179:57e3:3c75:1886ov94o0":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583"},"ASN":{}}}`,
+			// TODO - remove alt after updating json annotations to omitempty.
+			alt: `{"127.0.0.1ov94o0":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583","latitude":0,"longitude":0},"ASN":{}},"2620:0:1003:1008:5179:57e3:3c75:1886ov94o0":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583","latitude":0,"longitude":0},"ASN":{}}}`,
 		},
 	}
 	handler.CurrentGeoDataset = &parser.GeoDataset{
@@ -207,7 +211,7 @@ func TestBatchAnnotate(t *testing.T) {
 		r := httptest.NewRequest("POST", "/batch_annotate", strings.NewReader(test.body))
 		handler.BatchAnnotate(w, r)
 		body := w.Body.String()
-		if string(body) != test.res {
+		if string(body) != test.res && string(body) != test.alt {
 			t.Errorf("\nGot\n__%s__\nexpected\n__%s__\n", body, test.res)
 		}
 	}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m-lab/annotation-service/common"
 	"github.com/m-lab/annotation-service/handler"
 	"github.com/m-lab/annotation-service/parser"
-	"github.com/m-lab/etl/annotation"
 )
 
 func TestAnnotate(t *testing.T) {
@@ -69,7 +69,7 @@ func TestAnnotate(t *testing.T) {
 func TestValidateAndParse(t *testing.T) {
 	tests := []struct {
 		req *http.Request
-		res *annotation.RequestData
+		res *common.RequestData
 		err error
 	}{
 		{
@@ -87,13 +87,13 @@ func TestValidateAndParse(t *testing.T) {
 		{
 			req: httptest.NewRequest("GET",
 				"http://example.com/annotate?ip_addr=127.0.0.1&since_epoch=10", nil),
-			res: &annotation.RequestData{"127.0.0.1", 4, time.Unix(10, 0)},
+			res: &common.RequestData{"127.0.0.1", 4, time.Unix(10, 0)},
 			err: nil,
 		},
 		{
 			req: httptest.NewRequest("GET",
 				"http://example.com/annotate?ip_addr=2620:0:1003:1008:5179:57e3:3c75:1886&since_epoch=10", nil),
-			res: &annotation.RequestData{"2620:0:1003:1008:5179:57e3:3c75:1886", 6, time.Unix(10, 0)},
+			res: &common.RequestData{"2620:0:1003:1008:5179:57e3:3c75:1886", 6, time.Unix(10, 0)},
 			err: nil,
 		},
 	}
@@ -119,7 +119,7 @@ func TestBatchValidateAndParse(t *testing.T) {
 	timeCon, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
 	tests := []struct {
 		source io.Reader
-		res    []annotation.RequestData
+		res    []common.RequestData
 		err    error
 	}{
 		{
@@ -134,7 +134,7 @@ func TestBatchValidateAndParse(t *testing.T) {
 		},
 		{
 			source: bytes.NewBufferString(`[]`),
-			res:    []annotation.RequestData{},
+			res:    []common.RequestData{},
 			err:    nil,
 		},
 		{
@@ -145,7 +145,7 @@ func TestBatchValidateAndParse(t *testing.T) {
 		{
 			source: bytes.NewBufferString(`[{"ip": "127.0.0.1", "timestamp": "2002-10-02T15:00:00Z"},` +
 				`{"ip": "2620:0:1003:1008:5179:57e3:3c75:1886", "timestamp": "2002-10-02T15:00:00Z"}]`),
-			res: []annotation.RequestData{
+			res: []common.RequestData{
 				{"127.0.0.1", 4, timeCon},
 				{"2620:0:1003:1008:5179:57e3:3c75:1886", 6, timeCon},
 			},
@@ -221,14 +221,14 @@ func TestBatchAnnotate(t *testing.T) {
 // returning a canned response
 func TestGetMetadataForSingleIP(t *testing.T) {
 	tests := []struct {
-		req *annotation.RequestData
-		res *annotation.GeoData
+		req *common.RequestData
+		res *common.GeoData
 	}{
 		{
-			req: &annotation.RequestData{"127.0.0.1", 4, time.Unix(0, 0)},
-			res: &annotation.GeoData{
-				Geo: &annotation.GeolocationIP{City: "Not A Real City", Postal_code: "10583"},
-				ASN: &annotation.IPASNData{}},
+			req: &common.RequestData{"127.0.0.1", 4, time.Unix(0, 0)},
+			res: &common.GeoData{
+				Geo: &common.GeolocationIP{City: "Not A Real City", Postal_code: "10583"},
+				ASN: &common.IPASNData{}},
 		},
 	}
 	handler.CurrentGeoDataset = &parser.GeoDataset{
@@ -266,21 +266,21 @@ func TestConvertIPNodeToGeoData(t *testing.T) {
 	tests := []struct {
 		node parser.IPNode
 		locs []parser.LocationNode
-		res  *annotation.GeoData
+		res  *common.GeoData
 	}{
 		{
 			node: parser.IPNode{LocationIndex: 0, PostalCode: "10583"},
 			locs: []parser.LocationNode{{CityName: "Not A Real City", RegionCode: "ME"}},
-			res: &annotation.GeoData{
-				Geo: &annotation.GeolocationIP{City: "Not A Real City", Postal_code: "10583", Region: "ME"},
-				ASN: &annotation.IPASNData{}},
+			res: &common.GeoData{
+				Geo: &common.GeolocationIP{City: "Not A Real City", Postal_code: "10583", Region: "ME"},
+				ASN: &common.IPASNData{}},
 		},
 		{
 			node: parser.IPNode{LocationIndex: -1, PostalCode: "10583"},
 			locs: nil,
-			res: &annotation.GeoData{
-				Geo: &annotation.GeolocationIP{Postal_code: "10583"},
-				ASN: &annotation.IPASNData{}},
+			res: &common.GeoData{
+				Geo: &common.GeolocationIP{Postal_code: "10583"},
+				ASN: &common.IPASNData{}},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
There are bugs in the json annotations in etl/annotator package, which this code depends on.  The bugs were hidden by spaces in the annotation, which causes part of the annotation to be ignored.  "string" does not behave as one might expect, but instead causes the field to be json encoded within a string, not simply json encoding of a string.  So, removing the spaces actually breaks the code.  Instead, removing all the field type annotations achieves the desired behavior without lint errors.

This PR adjusts the annotator code to be compatible with changes we need to make to the etl code.  We will need to do the annotator update before the etl update, so I am copying the common structs used by both into the annotator project.  Once that is deployed, we make corresponding updates in the etl project without breaking things.

Also adding omitempty for the lat/long fields, as it doesn't add any value to encode zero values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/71)
<!-- Reviewable:end -->
