### PR TITLE
double max instances

### DIFF
--- a/annotator.yaml
+++ b/annotator.yaml
@@ -18,7 +18,7 @@ resources:
 automatic_scaling:
   # We expect negligible load, so this is unlikely to trigger.
   min_num_instances: 2
-  max_num_instances: 10
+  max_num_instances: 20
   cool_down_period_sec: 1800
   cpu_utilization:
     target_utilization: 0.60


### PR DESCRIPTION
With the huge batch processing job, we need a bit more annotator headroom to avoid latency getting too bad.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/90)
<!-- Reviewable:end -->
