### PR TITLE
Add annotator loading logic

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -14,6 +14,11 @@ var (
 	// ErrNilDataset is returned when CurrentAnnotator is nil.
 	ErrNilDataset = errors.New("CurrentAnnotator is nil")
 
+	// ErrPendingAnnotatorLoad is returned when a new annotator is requested, but not yet loaded.
+	ErrPendingAnnotatorLoad = errors.New("annotator is loading")
+
+	ErrAnnotatorLoadFailed = errors.New("unable to load annoator")
+
 	// A mutex to make sure that we are not reading from the CurrentAnnotator
 	// pointer while trying to update it
 	currentDataMutex = &sync.RWMutex{}
@@ -22,6 +27,72 @@ var (
 	// latest data for the annotator to search and reply with
 	CurrentAnnotator api.Annotator
 )
+
+// AnnotatorMap manages all loading of and already loaded Annotators
+type AnnotatorMap struct {
+	// Keys are date strings in YYYYMMDD format.
+	annotators map[string]api.Annotator
+	// Lock to be held when reading or writing the map.
+	mutex sync.RWMutex
+}
+
+// NOTE: Should only be called by checkAndLoadAnnotator.
+// Loads an annotator, and updates the pending map entry.
+// On entry, the calling goroutine should "own" the
+func (am *AnnotatorMap) loadAnnotator(dateString string) {
+	// On entry, this goroutine has exclusive ownership of the
+	// map entry, and the responsibility for loading the annotator.
+	var ann api.Annotator = nil
+	// TODO actually load the annotator and handle loading errors.
+
+	am.mutex.Lock()
+	defer am.mutex.Unlock()
+
+	ann, ok := am.annotators[dateString]
+	if !ok {
+		// TODO handle error
+	}
+	if ann != nil {
+		// TODO handle error
+	}
+	am.annotators[dateString] = ann
+}
+
+// This asynchronously attempts to set map entry to nil, and
+// if successful, proceeds to asynchronously load the new dataset.
+func (am *AnnotatorMap) checkAndLoadAnnotator(dateString string) {
+	go func() {
+		am.mutex.Lock()
+
+		_, ok := am.annotators[dateString]
+		if ok {
+			// Another goroutine is already responsible for loading.
+			am.mutex.Unlock()
+			return
+		} else {
+			// Place marker so that other requesters know it is loading.
+			am.annotators[dateString] = nil
+		}
+
+		// Drop the lock before attempting to load the annotator.
+		am.mutex.Unlock()
+		am.loadAnnotator(dateString)
+	}()
+}
+
+// Gets the named annotator, if already in the map.
+func (am *AnnotatorMap) GetAnnotator(dateString string) (api.Annotator, error) {
+	am.mutex.RLock()
+	defer am.mutex.RUnlock()
+
+	ann, ok := am.annotators[dateString]
+	if ok {
+		return ann, nil
+	} else {
+		am.checkAndLoadAnnotator(dateString)
+		return nil, ErrPendingAnnotatorLoad
+	}
+}
 
 // GetAnnotator returns the correct annotator to use for a given timestamp.
 func GetAnnotator(date time.Time) api.Annotator {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -42,7 +42,7 @@ type AnnotatorMap struct {
 func (am *AnnotatorMap) loadAnnotator(dateString string) {
 	// On entry, this goroutine has exclusive ownership of the
 	// map entry, and the responsibility for loading the annotator.
-	var ann api.Annotator = nil
+	var ann api.Annotator = &geolite2.GeoDataset{}
 	// TODO actually load the annotator and handle loading errors.
 
 	am.mutex.Lock()

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -90,12 +90,14 @@ func (am *AnnotatorMap) GetAnnotator(dateString string) (api.Annotator, error) {
 	defer am.mutex.RUnlock()
 
 	ann, ok := am.annotators[dateString]
-	if ok {
-		return ann, nil
-	} else {
+	if !ok {
 		am.checkAndLoadAnnotator(dateString)
 		return nil, ErrPendingAnnotatorLoad
 	}
+	if ann == nil {
+		return nil, ErrPendingAnnotatorLoad
+	}
+	return ann, nil
 }
 
 // GetAnnotator returns the correct annotator to use for a given timestamp.

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -17,6 +17,7 @@ var (
 	// ErrPendingAnnotatorLoad is returned when a new annotator is requested, but not yet loaded.
 	ErrPendingAnnotatorLoad = errors.New("annotator is loading")
 
+	// ErrAnnotatorLoadFailed is returned when a requested annotator has failed to load.
 	ErrAnnotatorLoadFailed = errors.New("unable to load annoator")
 
 	// A mutex to make sure that we are not reading from the CurrentAnnotator
@@ -28,7 +29,8 @@ var (
 	CurrentAnnotator api.Annotator
 )
 
-// AnnotatorMap manages all loading of and already loaded Annotators
+// AnnotatorMap manages all loading and fetching of Annotators.
+// TODO - should we call this AnnotatorCache?
 // TODO - should this be a generic cache of interface{}?
 type AnnotatorMap struct {
 	// Keys are date strings in YYYYMMDD format.
@@ -83,18 +85,18 @@ func (am *AnnotatorMap) checkAndLoadAnnotator(dateString string) {
 			// Another goroutine is already responsible for loading.
 			am.mutex.Unlock()
 			return
-		} else {
-			// Place marker so that other requesters know it is loading.
-			am.annotators[dateString] = nil
 		}
 
+		// Place marker so that other requesters know it is loading.
+		am.annotators[dateString] = nil
 		// Drop the lock before attempting to load the annotator.
 		am.mutex.Unlock()
 		am.loadAnnotator(dateString)
 	}()
 }
 
-// Gets the named annotator, if already in the map.
+// GetAnnotator gets the named annotator, if already in the map.
+// If not already loaded, this will trigger loading, and return ErrPendingAnnotatorLoad
 func (am *AnnotatorMap) GetAnnotator(dateString string) (api.Annotator, error) {
 	am.mutex.RLock()
 	defer am.mutex.RUnlock()

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -36,13 +36,17 @@ type AnnotatorMap struct {
 	mutex sync.RWMutex
 }
 
+func NewAnnotatorMap() *AnnotatorMap {
+	return &AnnotatorMap{annotators: make(map[string]api.Annotator, 10)}
+}
+
 // NOTE: Should only be called by checkAndLoadAnnotator.
 // Loads an annotator, and updates the pending map entry.
 // On entry, the calling goroutine should "own" the
 func (am *AnnotatorMap) loadAnnotator(dateString string) {
 	// On entry, this goroutine has exclusive ownership of the
 	// map entry, and the responsibility for loading the annotator.
-	var ann api.Annotator = &geolite2.GeoDataset{}
+	var newAnn api.Annotator = &geolite2.GeoDataset{}
 	// TODO actually load the annotator and handle loading errors.
 
 	am.mutex.Lock()
@@ -55,7 +59,7 @@ func (am *AnnotatorMap) loadAnnotator(dateString string) {
 	if ann != nil {
 		// TODO handle error
 	}
-	am.annotators[dateString] = ann
+	am.annotators[dateString] = newAnn
 }
 
 // This asynchronously attempts to set map entry to nil, and

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -5,11 +5,17 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/m-lab/annotation-service/api"
+	"github.com/m-lab/annotation-service/geolite2"
 	"github.com/m-lab/annotation-service/manager"
 )
 
+func fakeLoader(date string) (api.Annotator, error) {
+	return &geolite2.GeoDataset{}, nil
+}
+
 func TestAnnotatorMap(t *testing.T) {
-	am := manager.NewAnnotatorMap()
+	am := manager.NewAnnotatorMap(fakeLoader)
 
 	ann, err := am.GetAnnotator("20110101")
 	if err != manager.ErrPendingAnnotatorLoad {

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -1,0 +1,39 @@
+package manager_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/m-lab/annotation-service/manager"
+)
+
+func TestAnnotatorMap(t *testing.T) {
+	am := manager.NewAnnotatorMap()
+
+	ann, err := am.GetAnnotator("20110101")
+	if err != manager.ErrPendingAnnotatorLoad {
+		t.Error("Should be", manager.ErrPendingAnnotatorLoad)
+	}
+
+	ann, err = am.GetAnnotator("20110102")
+	if err != manager.ErrPendingAnnotatorLoad {
+		t.Error("Should be", manager.ErrPendingAnnotatorLoad)
+	}
+
+	// HACK - wait until the two goroutines complete.
+	// Not sure if this is stable across implementations.
+	// Wait for goroutines to complete.
+	for runtime.NumGoroutine() > 3 {
+	}
+
+	ann, err = am.GetAnnotator("20110102")
+	if err != nil {
+		t.Error("Not expecting:", err)
+	}
+	if ann == nil {
+		t.Error("Expecting non-nil annotator")
+	}
+	if runtime.NumGoroutine() != 3 {
+		t.Error(runtime.NumGoroutine())
+	}
+}


### PR DESCRIPTION
This adds the top level logic for managing a cache of Annotator objects, and loading new ones.  It does not yet address unloading Annotators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/129)
<!-- Reviewable:end -->
