### PR TITLE
Add v2.0 annotator request api and implement in handler.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -57,11 +57,13 @@ type RequestWrapper struct {
 	Body        json.RawMessage
 }
 
+// RequestVersion2 is the string associated with v2.0 requests.
 const RequestVersion2 = "Annotate v2.0"
 
 // AltRequest describes the data we expect to receive (json encoded) in the request body.
 type AltRequest struct {
 	RequestType string    // This should contain "Annotate v2.0"
+	RequestInfo string    // Arbitrary info about the requester, to be used, e.g., for stats.
 	Date        time.Time // The date to be used to annotate the addresses.
 	IPs         []net.IP  // The net.IP addresses to be annotated
 }
@@ -72,7 +74,7 @@ type Annotator interface {
 	// TODO return struct instead of pointer.
 	GetAnnotation(request *RequestData) (*GeoData, error)
 	// These return the date range covered by the annotator.
-	// TODO StartDate() time.Time
+	StartDate() time.Time
 	// TODO GetEndDate() time.Time
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -60,12 +60,18 @@ type RequestWrapper struct {
 // RequestVersion2 is the string associated with v2.0 requests.
 const RequestVersion2 = "Annotate v2.0"
 
-// AltRequest describes the data we expect to receive (json encoded) in the request body.
-type AltRequest struct {
+// RequestV2 describes the data we expect to receive (json encoded) in the request body.
+type RequestV2 struct {
 	RequestType string    // This should contain "Annotate v2.0"
 	RequestInfo string    // Arbitrary info about the requester, to be used, e.g., for stats.
 	Date        time.Time // The date to be used to annotate the addresses.
 	IPs         []net.IP  // The net.IP addresses to be annotated
+}
+
+type ResponseV2 struct {
+	// TODO should we include additional metadata about the annotator sources?  Perhaps map of filenames?
+	StartDate   time.Time           // The StartDate of the dataset used for the annotation
+	Annotations map[string]*GeoData // Map from human readable IP address to GeoData
 }
 
 // Annotator provides the GetAnnotation method, which retrieves the annotation for a given IP address.

--- a/api/api.go
+++ b/api/api.go
@@ -57,12 +57,13 @@ type RequestWrapper struct {
 	Body        json.RawMessage
 }
 
-// The RequestData schema is the schema for the json that we will send
-// down the pipe to the annotation service.
-type AltRequestData struct {
-	RequestType string
-	Date        time.Time
-	IPs         []net.IP
+const RequestVersion2 = "Annotate v2.0"
+
+// AltRequest describes the data we expect to receive (json encoded) in the request body.
+type AltRequest struct {
+	RequestType string    // This should contain "Annotate v2.0"
+	Date        time.Time // The date to be used to annotate the addresses.
+	IPs         []net.IP  // The net.IP addresses to be annotated
 }
 
 // Annotator provides the GetAnnotation method, which retrieves the annotation for a given IP address.

--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,10 @@ import (
 	"time"
 )
 
+/*************************************************************************
+*                             Annotation Structs                         *
+*************************************************************************/
+
 // The GeolocationIP struct contains all the information needed for the
 // geolocation data that will be inserted into big query. The fiels are
 // capitalized for exporting, although the originals in the DB schema
@@ -41,6 +45,10 @@ type GeoData struct {
 	ASN *IPASNData     // Holds the IP/ASN data
 }
 
+/*************************************************************************
+*                       Request/Response Structs                         *
+*************************************************************************/
+
 // The RequestData schema is the schema for the json that we will send
 // down the pipe to the annotation service.
 // DEPRECATED
@@ -57,8 +65,8 @@ type RequestWrapper struct {
 	Body        json.RawMessage
 }
 
-// RequestVersion2 is the string associated with v2.0 requests.
-const RequestVersion2 = "Annotate v2.0"
+// RequestV2Tag is the string associated with v2.0 requests.
+const RequestV2Tag = "Annotate v2.0"
 
 // RequestV2 describes the data we expect to receive (json encoded) in the request body.
 type RequestV2 struct {
@@ -68,11 +76,16 @@ type RequestV2 struct {
 	IPs         []net.IP  // The net.IP addresses to be annotated
 }
 
+// ResponseV2 describes data returned in V2 responses (json encoded).
 type ResponseV2 struct {
 	// TODO should we include additional metadata about the annotator sources?  Perhaps map of filenames?
 	StartDate   time.Time           // The StartDate of the dataset used for the annotation
 	Annotations map[string]*GeoData // Map from human readable IP address to GeoData
 }
+
+/*************************************************************************
+*                           Local Annotator API                          *
+*************************************************************************/
 
 // Annotator provides the GetAnnotation method, which retrieves the annotation for a given IP address.
 type Annotator interface {

--- a/api/api.go
+++ b/api/api.go
@@ -5,7 +5,6 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"net"
 	"regexp"
 	"time"
 )
@@ -73,7 +72,7 @@ type RequestV2 struct {
 	RequestType string    // This should contain "Annotate v2.0"
 	RequestInfo string    // Arbitrary info about the requester, to be used, e.g., for stats.
 	Date        time.Time // The date to be used to annotate the addresses.
-	IPs         []net.IP  // The net.IP addresses to be annotated
+	IPs         []string  // The IP addresses to be annotated
 }
 
 // ResponseV2 describes data returned in V2 responses (json encoded).
@@ -90,8 +89,7 @@ type ResponseV2 struct {
 // Annotator provides the GetAnnotation method, which retrieves the annotation for a given IP address.
 type Annotator interface {
 	// TODO use net.IP, and drop the bool
-	// TODO return struct instead of pointer.
-	GetAnnotation(request *RequestData) (*GeoData, error)
+	GetAnnotation(request *RequestData) (GeoData, error)
 	// These return the date range covered by the annotator.
 	StartDate() time.Time
 	// TODO GetEndDate() time.Time

--- a/api/api.go
+++ b/api/api.go
@@ -3,7 +3,9 @@
 package api
 
 import (
+	"encoding/json"
 	"errors"
+	"net"
 	"regexp"
 	"time"
 )
@@ -49,13 +51,27 @@ type RequestData struct {
 	Timestamp time.Time // Holds the timestamp from an incoming request
 }
 
+// RequestWrapper will be used for all future request types.
+type RequestWrapper struct {
+	RequestType string
+	Body        json.RawMessage
+}
+
+// The RequestData schema is the schema for the json that we will send
+// down the pipe to the annotation service.
+type AltRequestData struct {
+	RequestType string
+	Date        time.Time
+	IPs         []net.IP
+}
+
 // Annotator provides the GetAnnotation method, which retrieves the annotation for a given IP address.
 type Annotator interface {
 	// TODO use net.IP, and drop the bool
 	// TODO return struct instead of pointer.
 	GetAnnotation(request *RequestData) (*GeoData, error)
 	// These return the date range covered by the annotator.
-	// TODO GetStartDate() time.Time
+	// TODO StartDate() time.Time
 	// TODO GetEndDate() time.Time
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,7 +1,9 @@
 package api_test
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/m-lab/annotation-service/api"
 )
@@ -15,5 +17,39 @@ func TestExtractDateFromFilename(t *testing.T) {
 	date2, err := api.ExtractDateFromFilename("Maxmind/2017/10/05/20171005T033334Z-GeoLite2-City-CSV.zip")
 	if date2.Year() != 2017 || date2.Month() != 10 || date2.Day() != 5 || err != nil {
 		t.Errorf("Did not extract data correctly. Expected %d, got %v, %+v.", 20171005, date2, err)
+	}
+}
+
+func TestRequestWrapper(t *testing.T) {
+	req := api.AltRequestData{RequestType: "foobar"}
+
+	bytes, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wrapper := api.RequestWrapper{}
+	err = json.Unmarshal(bytes, &wrapper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	switch wrapper.RequestType {
+	case req.RequestType:
+		err = json.Unmarshal(bytes, &req)
+		if err != nil {
+			t.Fatal(err)
+		}
+	default:
+		t.Fatal("wrong request type:", wrapper.RequestType)
+	}
+
+	oldReq := []api.RequestData{{"IP", 4, time.Time{}}}
+	bytes, err = json.Marshal(oldReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = json.Unmarshal(bytes, &wrapper)
+	if err == nil {
+		t.Fatal("Should have produced json unmarshal error")
 	}
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -21,7 +21,7 @@ func TestExtractDateFromFilename(t *testing.T) {
 }
 
 func TestRequestWrapper(t *testing.T) {
-	req := api.AltRequest{RequestType: "foobar"}
+	req := api.RequestV2{RequestType: "foobar"}
 
 	bytes, err := json.Marshal(req)
 	if err != nil {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -21,7 +21,7 @@ func TestExtractDateFromFilename(t *testing.T) {
 }
 
 func TestRequestWrapper(t *testing.T) {
-	req := api.AltRequestData{RequestType: "foobar"}
+	req := api.AltRequest{RequestType: "foobar"}
 
 	bytes, err := json.Marshal(req)
 	if err != nil {

--- a/geolite2/geo-g2.go
+++ b/geolite2/geo-g2.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 
 	"cloud.google.com/go/storage"
+	"github.com/m-lab/annotation-service/api"
 	"github.com/m-lab/annotation-service/loader"
 	"google.golang.org/api/iterator"
 )
@@ -308,7 +309,17 @@ func LoadGeoLite2Dataset(filename string, bucketname string) (*GeoDataset, error
 	if err != nil {
 		return nil, err
 	}
-	return loadGeoLite2(zip)
+	dataset, err := loadGeoLite2(zip)
+	if err != nil {
+		return nil, err
+	}
+	date, err := api.ExtractDateFromFilename(filename)
+	if err != nil {
+		log.Println("Error extracting date:", filename)
+	} else {
+		dataset.start = date
+	}
+	return dataset, nil
 }
 
 // LoadLatestGeolite2File will check GCS for the latest file, download

--- a/geolite2/geo-ip.go
+++ b/geolite2/geo-ip.go
@@ -43,6 +43,7 @@ type LocationNode struct {
 // The GeoDataset struct bundles all the data needed to search and
 // find data into one common structure
 type GeoDataset struct {
+	start         time.Time      // Date from which to start using this dataset
 	IP4Nodes      []IPNode       // The IPNode list containing IP4Nodes
 	IP6Nodes      []IPNode       // The IPNode list containing IP6Nodes
 	LocationNodes []LocationNode // The location nodes corresponding to the IPNodes
@@ -127,7 +128,7 @@ func (ds *GeoDataset) GetAnnotation(request *api.RequestData) (*api.GeoData, err
 // StartDate returns the date that the dataset was published.
 // TODO implement actual dataset time!!
 func (ds *GeoDataset) StartDate() time.Time {
-	return time.Time{}
+	return ds.start
 }
 
 // Verify column length

--- a/geolite2/geo-ip.go
+++ b/geolite2/geo-ip.go
@@ -82,12 +82,12 @@ func (ds *GeoDataset) SearchBinary(ipLookUp string, IsIP4 bool) (p IPNode, e err
 // locationNodes. It will then use that data to fill in a GeoData
 // struct and return its pointer.
 // TODO make this unexported
-func convertIPNodeToGeoData(ipNode IPNode, locationNodes []LocationNode) *api.GeoData {
+func convertIPNodeToGeoData(ipNode IPNode, locationNodes []LocationNode) api.GeoData {
 	locNode := LocationNode{}
 	if ipNode.LocationIndex >= 0 {
 		locNode = locationNodes[ipNode.LocationIndex]
 	}
-	return &api.GeoData{
+	return api.GeoData{
 		Geo: &api.GeolocationIP{
 			ContinentCode: locNode.ContinentCode,
 			CountryCode:   locNode.CountryCode,
@@ -108,7 +108,7 @@ func convertIPNodeToGeoData(ipNode IPNode, locationNodes []LocationNode) *api.Ge
 
 // GetAnnotation looks up the IP address and returns the corresponding GeoData
 // TODO - improve the format handling.  Perhaps pass in a net.IP ?
-func (ds *GeoDataset) GetAnnotation(request *api.RequestData) (*api.GeoData, error) {
+func (ds *GeoDataset) GetAnnotation(request *api.RequestData) (api.GeoData, error) {
 	var node IPNode
 	err := errors.New("unknown IP format")
 	node, err = ds.SearchBinary(request.IP, request.IPFormat == 4)
@@ -119,7 +119,7 @@ func (ds *GeoDataset) GetAnnotation(request *api.RequestData) (*api.GeoData, err
 			log.Println(err, request.IP)
 		}
 		//TODO metric here
-		return nil, err
+		return api.GeoData{}, err
 	}
 
 	return convertIPNodeToGeoData(node, ds.LocationNodes), nil

--- a/geolite2/geo-ip_test.go
+++ b/geolite2/geo-ip_test.go
@@ -86,19 +86,19 @@ func TestConvertIPNodeToGeoData(t *testing.T) {
 	tests := []struct {
 		node geolite2.IPNode
 		locs []geolite2.LocationNode
-		res  *api.GeoData
+		res  api.GeoData
 	}{
 		{
 			node: geolite2.IPNode{LocationIndex: 0, PostalCode: "10583"},
 			locs: []geolite2.LocationNode{{CityName: "Not A Real City", RegionCode: "ME"}},
-			res: &api.GeoData{
+			res: api.GeoData{
 				Geo: &api.GeolocationIP{City: "Not A Real City", PostalCode: "10583", Region: "ME"},
 				ASN: &api.IPASNData{}},
 		},
 		{
 			node: geolite2.IPNode{LocationIndex: -1, PostalCode: "10583"},
 			locs: nil,
-			res: &api.GeoData{
+			res: api.GeoData{
 				Geo: &api.GeolocationIP{PostalCode: "10583"},
 				ASN: &api.IPASNData{}},
 		},

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -281,7 +281,7 @@ func handleNewOrOld(w http.ResponseWriter, jsonBuffer []byte) {
 		handleOld(w, jsonBuffer)
 	} else {
 		switch wrapper.RequestType {
-		case api.RequestVersion2:
+		case api.RequestV2Tag:
 			handleV2(w, jsonBuffer)
 		default:
 			// TODO Add metric

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -148,7 +149,7 @@ func TestBatchValidateAndParse(t *testing.T) {
 		{
 			source: bytes.NewBufferString(`[{"ip": "Bad IP", "timestamp": "2002-10-02T15:00:00Z"}]`),
 			res:    nil,
-			err:    errors.New("Invalid IP address."),
+			err:    errors.New("invalid IP address"),
 		},
 		{
 			source: bytes.NewBufferString(`[{"ip": "127.0.0.1", "timestamp": "2002-10-02T15:00:00Z"},` +
@@ -160,13 +161,26 @@ func TestBatchValidateAndParse(t *testing.T) {
 			err: nil,
 		},
 	}
-	for _, test := range tests {
-		res, err := handler.BatchValidateAndParse(test.source)
+	for i, test := range tests {
+		jsonBuffer, err := ioutil.ReadAll(test.source)
+		if err != nil {
+			if err.Error() != test.err.Error() {
+				log.Printf("Expected %T\n", test.err)
+				t.Error(err)
+			}
+			continue
+		}
+		res, err := handler.BatchValidateAndParse(jsonBuffer)
 		if !reflect.DeepEqual(res, test.res) {
-			t.Errorf("Expected %+v, got %+v.", test.res, res)
+			t.Errorf("Test %d: Expected %+v, got %+v.", i, test.res, res)
 		}
 		if err != nil && test.err == nil || err == nil && test.err != nil {
-			t.Errorf("Expected %+v, got %+v.", test.err, err)
+			t.Errorf("Test %d: Expected %+v, got %+v.", i, test.err, err)
+			continue
+		}
+		if err != nil && test.err != nil && err.Error() != test.err.Error() {
+			t.Errorf("Test %d: Expected %+v, got %+v.", i, test.err, err)
+			continue
 		}
 	}
 

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -245,11 +245,11 @@ func TestBatchAnnotate(t *testing.T) {
 func TestGetMetadataForSingleIP(t *testing.T) {
 	tests := []struct {
 		req *api.RequestData
-		res *api.GeoData
+		res api.GeoData
 	}{
 		{
 			req: &api.RequestData{IP: "127.0.0.1", IPFormat: 4, Timestamp: time.Unix(0, 0)},
-			res: &api.GeoData{
+			res: api.GeoData{
 				Geo: &api.GeolocationIP{City: "Not A Real City", PostalCode: "10583"},
 				ASN: &api.IPASNData{}},
 		},

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -26,6 +26,14 @@ var (
 		Name: "annotator_Annotation_Lookups_total",
 		Help: "The total number of ip lookups.",
 	})
+	BadIPTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "annotator_Bad_IP_Addresses_total",
+		Help: "The total number of ip parse failures.",
+	})
+	ErrorTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "annotator_Error_total",
+		Help: "The total number annotation errors.",
+	})
 )
 
 func init() {
@@ -33,6 +41,8 @@ func init() {
 	prometheus.MustRegister(TotalRequests)
 	prometheus.MustRegister(TotalLookups)
 	prometheus.MustRegister(RequestTimes)
+	prometheus.MustRegister(BadIPTotal)
+	prometheus.MustRegister(ErrorTotal)
 }
 
 // SetupPrometheus sets up and runs a webserver to export prometheus metrics.


### PR DESCRIPTION
This defines the V2.0 request api. From here on, request structs will include a leading string tag to indicate the api version. The V2.0 tag string is "Annotate v2.0"

Also
1. cleans up a couple TODOs, e.g., making GeoData return by value instead of pointer.
2. Adds new metrics for annotation errors and bad IP addresses.