### PR TITLE
Sandbox fix flake

### DIFF
--- a/geolite2/geo-g2.go
+++ b/geolite2/geo-g2.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	ipNumColumnsGlite2        = 10
-	locationNumColumnsGlite2  = 13
+	glite2LocationMinColumns  = 13
 	gLite2Prefix              = "GeoLite2-City"
 	geoLite2BlocksFilenameIP4 = "GeoLite2-City-Blocks-IPv4.csv"  // Filename of ipv4 blocks file
 	geoLite2BlocksFilenameIP6 = "GeoLite2-City-Blocks-IPv6.csv"  // Filename of ipv6 blocks file
@@ -108,16 +108,14 @@ func LoadLocListGLite2(reader io.Reader) ([]LocationNode, map[int]int, error) {
 	}
 	// TODO - this is a bit hacky.  May want to improve it.
 	// Older geoLite2 have 13 columns, but since 2018/03, they have 14 columns.
-	// This will print a log every time it loads a newer location file.
-	if len(first) != locationNumColumnsGlite2 {
-		log.Println("Incorrect number of columns in header, got: ", len(first), " wanted: ", locationNumColumnsGlite2)
-		log.Println(first)
-		if len(first) < locationNumColumnsGlite2 {
+	// Added last column is is_in_european_union
+	if len(first) != glite2LocationMinColumns {
+		if len(first) < glite2LocationMinColumns {
 			return nil, nil, errors.New("Corrupted Data: wrong number of columns")
 		}
 	}
 	// FieldsPerRecord is the expected column length
-	// r.FieldsPerRecord = locationNumColumnsGlite2
+	// r.FieldsPerRecord = glite2LocationMinColumns
 	errorCount := 0
 	maxErrorCount := 50
 	for {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -34,9 +34,12 @@ func InitHandler() {
 	http.HandleFunc("/annotate", Annotate)
 	http.HandleFunc("/batch_annotate", BatchAnnotate)
 
+	// DEPRECATED
+	// This code is disabled, to deal with a confusing pubsub subscription quota.
+	// It is no longer needed because Ya implemented an external cron trigger.
 	// This listens for pubsub messages about new downloader files, and loads them
 	// when they become available.
-	go waitForDownloaderMessages()
+	// go waitForDownloaderMessages()
 }
 
 // Annotate is a URL handler that looks up IP address and puts

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -248,7 +248,8 @@ func GetAnnotator(date time.Time) (api.Annotator, error) {
 func InitDataset() {
 	geoloader.UpdateArchivedFilenames()
 
+	ann := geoloader.GetLatestData()
 	currentDataMutex.Lock()
-	CurrentAnnotator = geoloader.GetLatestData()
+	CurrentAnnotator = ann
 	currentDataMutex.Unlock()
 }

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -36,17 +36,18 @@ func TestAnnotatorMap(t *testing.T) {
 	// These are all fake names.
 	_, err := am.GetAnnotator(names[0])
 	if err != manager.ErrPendingAnnotatorLoad {
-		t.Error("Should be", manager.ErrPendingAnnotatorLoad)
+		t.Fatal("Should be", manager.ErrPendingAnnotatorLoad)
 	}
 
 	_, err = am.GetAnnotator(names[1])
 	if err != manager.ErrPendingAnnotatorLoad {
-		t.Error("Should be", manager.ErrPendingAnnotatorLoad)
+		t.Fatal("Should be", manager.ErrPendingAnnotatorLoad)
 	}
 
+	// This one should NOT kick off a load, because numPending already max.
 	_, err = am.GetAnnotator(names[2])
 	if err != manager.ErrPendingAnnotatorLoad {
-		t.Error("Should be", manager.ErrPendingAnnotatorLoad)
+		t.Fatal("Should be", manager.ErrPendingAnnotatorLoad)
 	}
 
 	// Wait for both annotator to be available.
@@ -68,6 +69,7 @@ func TestAnnotatorMap(t *testing.T) {
 	}(names[1])
 	wg.Wait()
 
+	// Verify that both annotators are now available.
 	ann, err := am.GetAnnotator(names[0])
 	if err != nil {
 		t.Error("Not expecting:", err)
@@ -76,36 +78,55 @@ func TestAnnotatorMap(t *testing.T) {
 		t.Error("Expecting non-nil annotator")
 	}
 
-	// Now try to load 2 more.  The second one should cause an eviction.
-	wg = &sync.WaitGroup{}
-	wg.Add(2)
-	go func(date string) {
+	ann, err = am.GetAnnotator(names[1])
+	if err != nil {
+		t.Error("Not expecting:", err)
+	}
+	if ann == nil {
+		t.Error("Expecting non-nil annotator")
+	}
+
+	// Verify that third is NOT available.  This kicks off loading.
+	_, err = am.GetAnnotator(names[2])
+	if err != manager.ErrPendingAnnotatorLoad {
+		t.Fatal("Should be", manager.ErrPendingAnnotatorLoad)
+	}
+
+	// Wait until it has loaded.
+	func(date string) {
 		err := errors.New("start")
 		for ; err != nil; _, err = am.GetAnnotator(date) {
 			time.Sleep(3 * time.Millisecond)
 		}
-		wg.Done()
 	}(names[2])
-	go func(date string) {
-		err := errors.New("start")
-		for ; err != nil; _, err = am.GetAnnotator(date) {
-			time.Sleep(3 * time.Millisecond)
-		}
-		wg.Done()
-	}(names[3])
-	wg.Wait()
+
+	// And now load the fourth.  This should cause synchronous eviction, and NOT cause loading.
+	_, err = am.GetAnnotator(names[3])
+	if err != manager.ErrPendingAnnotatorLoad {
+		t.Fatal("Should be", manager.ErrPendingAnnotatorLoad)
+	}
 
 	// Loading two more will have caused one to be evicted, so exactly one of these
 	// should no longer be loaded, and return an ErrPendingAnnotatorLoad.
+	// One of these checks will also trigger another load, but that is OK.
 	_, err0 := am.GetAnnotator(names[0])
 	_, err1 := am.GetAnnotator(names[1])
+	_, err2 := am.GetAnnotator(names[2])
 	switch {
-	case err0 == nil && err1 == nil:
+	case err0 == nil && err1 == nil && err2 == nil:
 		t.Error("One of the items should have been evicted")
-	case err0 == nil && err1 == manager.ErrPendingAnnotatorLoad:
-		// Good
-	case err0 == manager.ErrPendingAnnotatorLoad && err1 == nil:
-		// Good
+	case err0 == manager.ErrPendingAnnotatorLoad:
+		if err1 != nil || err2 != nil {
+			t.Error("More than one nil", err0, err1, err2)
+		}
+	case err1 == manager.ErrPendingAnnotatorLoad:
+		if err0 != nil || err2 != nil {
+			t.Error("More than one nil", err0, err1, err2)
+		}
+	case err2 == manager.ErrPendingAnnotatorLoad:
+		if err0 != nil || err1 != nil {
+			t.Error("More than one nil", err0, err1, err2)
+		}
 	default:
 		t.Error("Should have had exactly one ErrPending...", err0, err1)
 	}


### PR DESCRIPTION
The unit test for annotator loading is flaky.  This fixes it.
Runs successfully with -race -count=100

Also removed pubsub goroutine, and fixes a lock that is held too long.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/153)
<!-- Reviewable:end -->
