### PR TITLE
Add retry to external request API

### DIFF
--- a/api/v2/api-v2_test.go
+++ b/api/v2/api-v2_test.go
@@ -21,19 +21,37 @@ func init() {
 
 func TestDoRequest(t *testing.T) {
 	expectedJson := `{"AnnotatorDate":"2018-12-05T00:00:00Z","Annotations":{"147.1.2.3":{"Geo":{"continent_code":"NA","country_code":"US","country_name":"United States","latitude":37.751,"longitude":-97.822},"ASN":{}},"8.8.8.8":{"Geo":{"continent_code":"NA","country_code":"US","country_name":"United States","latitude":37.751,"longitude":-97.822},"ASN":{}}}}`
+	callCount := 0
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, expectedJson)
+		switch {
+		case callCount < 3:
+			w.WriteHeader(http.StatusServiceUnavailable)
+		default:
+			fmt.Fprint(w, expectedJson)
+		}
+		callCount++
 	}))
 	url := ts.URL
 
 	//url = "https://annotator-dot-mlab-sandbox.appspot.com/batch_annotate"
 	ips := []string{"8.8.8.8", "147.1.2.3"}
-	resp, err := api.GetAnnotations(context.Background(), url, time.Now(), ips)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	resp, err := api.GetAnnotations(ctx, url, time.Now(), ips)
+	if err == nil {
+		t.Fatal("Should have timed out")
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err = api.GetAnnotations(ctx, url, time.Now(), ips)
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	if callCount != 4 {
+		t.Error("Should have been two calls to server.")
+	}
 	expectedResponse := api.Response{}
 	err = json.Unmarshal([]byte(expectedJson), &expectedResponse)
 	if err != nil {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -272,11 +272,15 @@ func handleV2(w http.ResponseWriter, jsonBuffer []byte) {
 	// No need to validate IP addresses, as they are net.IP
 	response := v2.Response{}
 
-	// For now, use the date of the first item.  In future the items will not have individual timestamps.
 	if len(request.IPs) > 0 {
-		// For old request format, we use the date of the first RequestData
 		response, err = AnnotateV2(request.Date, request.IPs)
 		if err != nil {
+			switch err {
+			case manager.ErrPendingAnnotatorLoad:
+				w.WriteHeader(http.StatusServiceUnavailable)
+			default:
+				w.WriteHeader(http.StatusInternalServerError)
+			}
 			fmt.Fprintf(w, err.Error())
 			return
 		}


### PR DESCRIPTION
This adds retry for ServiceUnavailable, and latency and type metrics.  This provides a simple external http request wrapper api that can be compiled into ETL (or other clients).