### PR TITLE
fix misplaced defer close

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -28,11 +28,11 @@ func CreateZipReader(ctx context.Context, bucket string, bucketObj string) (*zip
 
 	// Takes context returns *Reader
 	reader, err := obj.NewReader(ctx)
-	defer reader.Close()
 	if err != nil {
 		log.Println(err)
 		return nil, errors.New("Failed creating new reader")
 	}
+	defer reader.Close()
 	bytesSlice, err := ioutil.ReadAll(reader)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
This close causes segfault if the error path is taken.  Crashed an instance about an hour ago.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/172)
<!-- Reviewable:end -->
