### PR TITLE
Sandbox request metrics

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -36,7 +36,7 @@ func TestAnnotate(t *testing.T) {
 		res  string
 	}{
 		{"1.4.128.0", "625600", `{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583","latitude":42.1,"longitude":-73.1},"ASN":{}}`},
-		{"This will be an error.", "1000", "Invalid request"},
+		{"This will be an error.", "1000", "invalid IP address"},
 	}
 	// TODO - make and use an annotator generator
 	manager.CurrentAnnotator = &geolite2.GeoDataset{
@@ -198,7 +198,7 @@ func TestBatchAnnotate(t *testing.T) {
 	}{
 		{
 			body: "{",
-			res:  "Invalid Request!",
+			res:  "unexpected end of JSON input",
 			alt:  "",
 		},
 		{

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -290,6 +290,9 @@ func TestGetMetadataForSingleIP(t *testing.T) {
 }
 
 func TestE2ELoadMultipleDataset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test that uses GCS")
+	}
 	manager.InitDataset()
 	tests := []struct {
 		ip   string

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -137,6 +137,9 @@ func TestAnnotatorMap(t *testing.T) {
 }
 
 func TestE2ELoadMultipleDataset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test that uses GCS")
+	}
 	manager.InitDataset()
 	manager.MaxDatasetInMemory = 2
 	tests := []struct {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -22,6 +22,21 @@ var (
 		Name: "annotator_Request_Response_Time_Summary",
 		Help: "The response time of each request, in nanoseconds.",
 	})
+	RequestTimeHistogramUsec = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "annotator_latency_hist_usec",
+			Help: "annotator latency distributions.",
+			Buckets: []float64{
+				10, 13, 16, 20, 25, 32, 40, 50, 63, 79,
+				100, 130, 160, 200, 250, 320, 400, 500, 630, 790,
+				1000, 1300, 1600, 2000, 2500, 3200, 4000, 5000, 6300, 7900,
+				10000, 13000, 16000, 20000, 25000, 32000, 40000, 50000, 63000, 79000,
+				100000, 130000, 160000, 200000, 250000, 320000, 400000, 500000, 630000, 790000,
+				1000000, 1300000, 1600000, 2000000, 2500000, 3200000, 4000000, 5000000, 6300000, 7900000,
+				10000000,
+			},
+		},
+		[]string{"type", "detail"})
 	TotalRequests = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "annotator_Annotation_Requests_total",
 		Help: "The total number of annotation service requests.",


### PR DESCRIPTION
The prototype we've been running a lot in sandbox has this metric, which has been very useful for understanding the incoming request traffic and latencies.

Also adds check for testing.Short() to allow avoiding tests that hit GCS.

FYI, this is the first panel at:
https://grafana.mlab-sandbox.measurementlab.net/d/uJ-abYEiz/pipeline-annotation-service-gfr?orgId=1&from=now-3h&to=now&var-interval=10m&var-service=All&var-datasource=Prometheus%20(mlab-sandbox)&panelId=23
The metric has a lot of old data, because sandbox has been running sandbox-semaphores-rebase, which includes this metric already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/177)
<!-- Reviewable:end -->
