### PR TITLE
avoid early legacy datasets

### DIFF
--- a/geoloader/filename.go
+++ b/geoloader/filename.go
@@ -162,11 +162,12 @@ func UpdateArchivedFilenames() error {
 		if err != nil {
 			continue
 		}
-		badDatasetDate, _ :=
-			time.Parse("20060102", "20140201")
-		if fileDate.Before(badDatasetDate) {
+
+		if fileDate.Before(GeoLite2StartDate) {
 			// The 2014/01/07 dataset does not load properly.  This causes all sidestream
 			// processing to stall.  So we just avoid all early datasets for now.
+			// ACTUALLY - turns out there are multiple bad datasets.  So we just avoid
+			// all legacy datasets until we have better persistent error handling.
 			// TODO - before removing this, implement a unit test that fails because of it.
 			continue
 		}

--- a/geoloader/filename.go
+++ b/geoloader/filename.go
@@ -162,9 +162,13 @@ func UpdateArchivedFilenames() error {
 		if err != nil {
 			continue
 		}
-		if fileDate.Before(GeoLite2StartDate) {
-			// temporary hack to avoid legacy
-			//continue
+		badDatasetDate, _ :=
+			time.Parse("20060102", "20140201")
+		if fileDate.Before(badDatasetDate) {
+			// The 2014/01/07 dataset does not load properly.  This causes all sidestream
+			// processing to stall.  So we just avoid all early datasets for now.
+			// TODO - before removing this, implement a unit test that fails because of it.
+			continue
 		}
 
 		if !fileDate.Before(GeoLite2StartDate) && !GeoLite2Regex.MatchString(file.Name) {


### PR DESCRIPTION
The 2014/01/07 dataset is missing the ipv4 data, so it causes a dataset load error, which causes progress to halt when data in that date range is processed.

This PR basically rejects all datasets prior to 2014/02, to avoid this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/179)
<!-- Reviewable:end -->
