### PR TITLE
init request latency metric

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -94,6 +94,7 @@ func init() {
 	prometheus.MustRegister(EvictionCount)
 	prometheus.MustRegister(LoadCount)
 	prometheus.MustRegister(RejectionCount)
+	prometheus.MustRegister(RequestTimeHistogramUsec)
 }
 
 // SetupPrometheus sets up and runs a webserver to export prometheus metrics.


### PR DESCRIPTION
Forgot to initialize the metric, so prometheus isn't scraping it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/181)
<!-- Reviewable:end -->
