### PR TITLE
separate latency for legacy vs geolite2

### DIFF
--- a/geoloader/geoloader.go
+++ b/geoloader/geoloader.go
@@ -231,3 +231,7 @@ func Geolite2Loader(
 		},
 		loader)
 }
+
+func IsLegacy(date time.Time) bool {
+	return date.Before(geoLite2StartDate)
+}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -276,10 +276,13 @@ func handleOld(w http.ResponseWriter, tStart time.Time, jsonBuffer []byte) {
 	fmt.Fprint(w, string(encodedResult))
 
 	if len(dataSlice) == 0 {
+		// Don't know if this was legacy or geolite2, so just label it "old"
 		latencyStats("old", len(dataSlice), tStart)
 	} else if geoloader.IsLegacy(dataSlice[0].Timestamp) {
+		// Label this old (api) and legacy (dataset)
 		latencyStats("old-legacy", len(dataSlice), tStart)
 	} else {
+		// Label this old (api) and geolite2 (dataset)
 		latencyStats("old-geolite2", len(dataSlice), tStart)
 	}
 }
@@ -308,8 +311,10 @@ func handleV2(w http.ResponseWriter, tStart time.Time, jsonBuffer []byte) {
 	}
 	fmt.Fprint(w, string(encodedResult))
 	if geoloader.IsLegacy(request.Date) {
+		// Label this v2 (api) and legacy (dataset)
 		latencyStats("v2-legacy", len(request.IPs), tStart)
 	} else {
+		// Label this v2 (api) and geolite2 (dataset)
 		latencyStats("v2-geolite2", len(request.IPs), tStart)
 	}
 }


### PR DESCRIPTION
This PR provides separate metrics for requests for legacy datasets, vs geolite2 datasets.  It provides insight that legacy annotations take about twice as along as geolite2 annotations, explaining the variation we see in processing latency over time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/213)
<!-- Reviewable:end -->
