### PR TITLE
Asn annotator - first phase

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -12,7 +12,8 @@ import (
 
 const (
 	// Folder containing the maxmind files
-	MaxmindPrefix = "Maxmind/"
+	MaxmindPrefix   = "Maxmind/"
+	RouteViewPrefix = "RouteView"
 )
 
 var (

--- a/asn/asn.go
+++ b/asn/asn.go
@@ -1,0 +1,315 @@
+package asn
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"errors"
+	"io"
+	"log"
+	"net"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/m-lab/annotation-service/api"
+	"github.com/m-lab/annotation-service/geolite2"
+	"github.com/m-lab/annotation-service/loader"
+	"github.com/m-lab/annotation-service/metrics"
+)
+
+var (
+	expectedColumnCount             = 3                                                              // the number of the expected columns in the source dataset
+	maxErrorCountPerFile            = 50                                                             // the maximum allowed error per import file
+	timeComponentsFromFileNameRegex = regexp.MustCompile(`.*(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2}).*`) // the regex, which helps to extract the time from the file name
+)
+
+// ASNDataset holds the database in the memory
+type ASNDataset struct {
+	IPList []ASNIPNode
+	Start  time.Time // Date from which to start using this dataset
+}
+
+// ASNIPNode represents a single line in the source dataset file.
+type ASNIPNode struct {
+	IPAddressLow  net.IP
+	IPAddressHigh net.IP
+	ASNString     string
+}
+
+var lastLogTime = time.Time{}
+
+// Annotate expects an IP string and an api.GeoData pointer to find the ASN
+// and populate the data into the GeoData.ASN struct
+func (asn *ASNDataset) Annotate(ip string, ann *api.GeoData) error {
+	if asn == nil {
+		return errors.New("ErrNilASNDataset") // TODO
+	}
+	if ann.ASN != nil {
+		return errors.New("ErrAlreadyPopulated") // TODO
+	}
+	node, err := asn.SearchBinary(ip)
+	if err != nil {
+		// ErrNodeNotFound is super spammy - 10% of requests, so suppress those.
+		if err != geolite2.ErrNodeNotFound {
+			// Horribly noisy now.
+			if time.Since(lastLogTime) > time.Minute {
+				log.Println(err, ip)
+				lastLogTime = time.Now()
+			}
+		}
+		//TODO metric here
+		return err
+	}
+
+	result := []api.ASNElement{}
+	for _, asn := range strings.Split(node.ASNString, ",") {
+		asnList := strings.Split(asn, "_")
+		newElement := api.ASNElement{ASNList: asnList, ASNListType: api.ASNSingle}
+		if len(asnList) > 1 {
+			newElement.ASNListType = api.ASNMultiOrigin
+		}
+		result = append(result, newElement)
+	}
+	ann.ASN = result
+	return nil
+}
+
+// The date associated with the dataset.
+func (asn *ASNDataset) AnnotatorDate() time.Time {
+	return asn.Start
+}
+
+// LoadASNDataset loads a dataset from a GCS object.
+func LoadASNDataset(file *storage.ObjectAttrs) (api.Annotator, error) {
+	dataFileName := loader.GetGzBase(file.Name)
+	err := loader.UncompressGzFile(context.Background(), file.Bucket, file.Name, dataFileName)
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(dataFileName)
+	nodes, err := loadData(dataFileName, file.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	time, err := ExtractTimeFromASNFileName(dataFileName)
+	if err != nil {
+		return nil, err
+	}
+	return &ASNDataset{IPList: nodes, Start: *time}, nil
+}
+
+// ExtractTimeFromASNFileName extract the start time of the dataset validity
+// from the name of the file.
+func ExtractTimeFromASNFileName(fileName string) (*time.Time, error) {
+	groups := timeComponentsFromFileNameRegex.FindStringSubmatch(fileName)
+	if groups == nil {
+		log.Printf("Could not extract time from ASN filename: %s\n", fileName)
+		return nil, errors.New("cannot extract date from input filename")
+	}
+
+	// We can be sure that we have integers in the groups, otherwise the regexp
+	// wouldn't match, so we cast those to int without error check
+	// Based on the docs, the time should be ment in UTC
+	t := time.Date(
+		asIntUnsafe(groups[1]),
+		time.Month(asIntUnsafe(groups[2])),
+		asIntUnsafe(groups[3]),
+		asIntUnsafe(groups[4]),
+		asIntUnsafe(groups[5]),
+		0,
+		0,
+		time.UTC)
+
+	return &t, nil
+}
+
+// asIntUnsafe converts the string to int without error check.
+// the caller should be sure about the passed string can be converted
+// to int
+func asIntUnsafe(knownIntStr string) int {
+	v, _ := strconv.Atoi(knownIntStr)
+	return v
+}
+
+// loadData loads the data into an ASNIPNode list
+// FIXME eliminate, it's a copy-paste of LoadIPListGLite2 from geo-g2.go
+func loadData(fileName, datasetName string) ([]ASNIPNode, error) {
+	file, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	reader := csv.NewReader(file)
+	reader.Comma = '\t'
+	reader.FieldsPerRecord = expectedColumnCount
+
+	list := []ASNIPNode{}
+	stack := []ASNIPNode{}
+
+	errorCount := 0
+	maxErrorCount := maxErrorCountPerFile
+	for {
+		var newNode ASNIPNode
+		record, err := reader.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			log.Println(err)
+			errorCount++
+			if errorCount > maxErrorCount {
+				return nil, errors.New("Too many errors during loading the dataset IP list.")
+			}
+			continue
+		}
+		ipString := strings.Join(record[:2], "/")
+		lowIP, highIP, err := rangeCIDR(ipString)
+		if err != nil {
+			log.Println(err)
+			errorCount++
+			if errorCount > maxErrorCount {
+				return nil, errors.New("Too many errors during loading the dataset IP list")
+			}
+			continue
+		}
+		newNode.IPAddressLow = lowIP
+		newNode.IPAddressHigh = highIP
+		newNode.ASNString = record[2]
+
+		stack, list = handleStack(stack, list, newNode)
+	}
+	var pop ASNIPNode
+	pop, stack = stack[len(stack)-1], stack[:len(stack)-1]
+	for ; len(stack) > 0; pop, stack = stack[len(stack)-1], stack[:len(stack)-1] {
+		peek := stack[len(stack)-1]
+		peek.IPAddressLow = PlusOne(pop.IPAddressHigh)
+		list = append(list, peek)
+	}
+	return list, nil
+}
+
+// Finds the smallest and largest net.IP from a CIDR range
+// Example: "1.0.0.0/24" -> 1.0.0.0 , 1.0.0.255
+// FIXME eliminate, it's a copy-paste of rangeCIDR from geo-g2.go
+func rangeCIDR(cidr string) (net.IP, net.IP, error) {
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, nil, errors.New("Invalid CIDR IP range")
+	}
+	lowIP := make(net.IP, len(ip))
+	copy(lowIP, ip)
+	mask := ipnet.Mask
+	for x := range ip {
+		if len(mask) == 4 {
+			if x < 12 {
+				ip[x] |= 0
+			} else {
+				ip[x] |= ^mask[x-12]
+			}
+		} else {
+			ip[x] |= ^mask[x]
+		}
+	}
+	return lowIP, ip, nil
+}
+
+// TODO(gfr) What are list and stack?
+// handleStack finds the proper place in the stack for the new node.
+// `stack` holds a stack of nested IP ranges not yet resolved.
+// `list` is the complete list of flattened IPNodes.
+// FIXME eliminate, it's a copy-paste of handleStqck from geo-ip.go
+func handleStack(stack, list []ASNIPNode, newNode ASNIPNode) ([]ASNIPNode, []ASNIPNode) {
+	// Stack is not empty aka we're in a nested IP
+	if len(stack) != 0 {
+		// newNode is no longer inside stack's nested IP's
+		if lessThan(stack[len(stack)-1].IPAddressHigh, newNode.IPAddressLow) {
+			// while closing nested IP's
+			var pop ASNIPNode
+			pop, stack = stack[len(stack)-1], stack[:len(stack)-1]
+			for ; len(stack) > 0; pop, stack = stack[len(stack)-1], stack[:len(stack)-1] {
+				peek := stack[len(stack)-1]
+				if lessThan(newNode.IPAddressLow, peek.IPAddressHigh) {
+					// if there's a gap in between adjacent nested IP's,
+					// complete the gap
+					peek.IPAddressLow = PlusOne(pop.IPAddressHigh)
+					peek.IPAddressHigh = minusOne(newNode.IPAddressLow)
+					list = append(list, peek)
+					break
+				}
+				peek.IPAddressLow = PlusOne(pop.IPAddressHigh)
+				list = append(list, peek)
+			}
+		} else {
+			// if we're nesting IP's
+			// create begnning bounds
+			lastListNode := &list[len(list)-1]
+			lastListNode.IPAddressHigh = minusOne(newNode.IPAddressLow)
+
+		}
+	}
+	stack = append(stack, newNode)
+	list = append(list, newNode)
+	return stack, list
+}
+
+// lessThan returns true if the net.IP in the first argument is lower than
+// the net.IP in the second argument
+// FIXME eliminate, it's a copy-paste of lessThan from geo-ip.go
+func lessThan(a, b net.IP) bool {
+	return bytes.Compare(a, b) < 0
+}
+
+// PlusOne adds one to a net.IP.
+// FIXME eliminate, it's a copy-paste of PlusOne from geo-ip.go
+func PlusOne(a net.IP) net.IP {
+	a = append([]byte(nil), a...)
+	var i int
+	for i = 15; a[i] == 255; i-- {
+		a[i] = 0
+	}
+	a[i]++
+	return a
+}
+
+// minusOne subtracts one of a net.IP
+// FIXME eliminate, it's a copy-paste of minusOne from geo-ip.go
+func minusOne(a net.IP) net.IP {
+	a = append([]byte(nil), a...)
+	var i int
+	for i = 15; a[i] == 0; i-- {
+		a[i] = 255
+	}
+	a[i]--
+	return a
+}
+
+// SearchBinary does a binary search for a list element.
+// FIXME eliminate, it's a copy-paste of BinarySearch from geo-ip.go
+func (ds *ASNDataset) SearchBinary(ipLookUp string) (p ASNIPNode, e error) {
+	ip := net.ParseIP(ipLookUp)
+	if ip == nil {
+		metrics.BadIPTotal.Inc()
+		return p, errors.New("ErrInvalidIP") // TODO
+	}
+	list := ds.IPList
+	start := 0
+	end := len(list) - 1
+
+	for start <= end {
+		median := (start + end) / 2
+		if bytes.Compare(ip, list[median].IPAddressLow) >= 0 && bytes.Compare(ip, list[median].IPAddressHigh) <= 0 {
+			return list[median], nil
+		}
+		if bytes.Compare(ip, list[median].IPAddressLow) > 0 {
+			start = median + 1
+		} else {
+			end = median - 1
+		}
+	}
+	return p, geolite2.ErrNodeNotFound
+}

--- a/asn/asn_test.go
+++ b/asn/asn_test.go
@@ -1,0 +1,174 @@
+package asn_test
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/m-lab/annotation-service/api"
+	"github.com/m-lab/annotation-service/geoloader"
+
+	"github.com/m-lab/annotation-service/asn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnnotateV4(t *testing.T) {
+	datasetsTime := time.Date(2019, 1, 1, 12, 0, 0, 0, time.UTC)
+	ann := getAnnotatorForDay(t, true, datasetsTime.Year(), int(datasetsTime.Month()), datasetsTime.Day(), datasetsTime)
+
+	// test simple ASN
+	geoData := api.GeoData{}
+	err := ann.Annotate("84.1.28.246", &geoData)
+	assert.Nil(t, err)
+	assertASNData(t,
+		[]api.ASNElement{
+			api.ASNElement{[]string{"5483"}, api.ASNSingle},
+		},
+		geoData.ASN)
+
+	// test set ASN
+	geoData.ASN = nil
+	err = ann.Annotate("43.224.118.23", &geoData)
+	assert.Nil(t, err)
+	assertASNData(t,
+		[]api.ASNElement{
+			api.ASNElement{[]string{"135001"}, api.ASNSingle},
+			api.ASNElement{[]string{"135527"}, api.ASNSingle},
+		},
+		geoData.ASN)
+
+	// test multi-origin ASN
+	geoData.ASN = nil
+	err = ann.Annotate("43.228.124.11", &geoData)
+	assert.Nil(t, err)
+	assertASNData(t,
+		[]api.ASNElement{
+			api.ASNElement{[]string{"133322", "133905"}, api.ASNMultiOrigin},
+		},
+		geoData.ASN)
+
+	// test already populated error
+	err = ann.Annotate("43.228.11", &geoData)
+	assert.EqualError(t, err, "ErrAlreadyPopulated")
+
+	// test bad IP error
+	geoData.ASN = nil
+	err = ann.Annotate("43.228.11", &geoData)
+	assert.EqualError(t, err, "ErrInvalidIP")
+}
+
+func TestAnnotateV6(t *testing.T) {
+	datasetsTime := time.Date(2019, 1, 1, 12, 0, 0, 0, time.UTC)
+	ann := getAnnotatorForDay(t, false, datasetsTime.Year(), int(datasetsTime.Month()), datasetsTime.Day(), datasetsTime)
+
+	// test simple ASN
+	geoData := api.GeoData{}
+	err := ann.Annotate("2001:408:8000:0000:0000:0000:0000:1313", &geoData)
+	assert.Nil(t, err)
+	assertASNData(t,
+		[]api.ASNElement{
+			api.ASNElement{[]string{"14793"}, api.ASNSingle},
+		},
+		geoData.ASN)
+
+	// test set ASN
+	// []string{"271", "7860", "8111"}
+	geoData.ASN = nil
+	err = ann.Annotate("2001:410:0000:0000:0000:0000:0000:1313", &geoData)
+	assert.Nil(t, err)
+	assertASNData(t,
+		[]api.ASNElement{
+			api.ASNElement{[]string{"271"}, api.ASNSingle},
+			api.ASNElement{[]string{"7860"}, api.ASNSingle},
+			api.ASNElement{[]string{"8111"}, api.ASNSingle},
+		},
+		geoData.ASN)
+
+	// test multi-origin ASN
+	geoData.ASN = nil
+	err = ann.Annotate("2001:2b8:90:0000:0000:0000:0000:1313", &geoData)
+	assert.Nil(t, err)
+	assertASNData(t,
+		[]api.ASNElement{
+			api.ASNElement{[]string{"17832", "1237"}, api.ASNMultiOrigin},
+		},
+		geoData.ASN)
+
+	// test already populated error
+	err = ann.Annotate("2001:2b8:i3", &geoData)
+	assert.EqualError(t, err, "ErrAlreadyPopulated")
+
+	// test bad IP error
+	geoData.ASN = nil
+	err = ann.Annotate("2001:2b8:i3", &geoData)
+	assert.EqualError(t, err, "ErrInvalidIP")
+}
+
+func TestExtractTimeFromASNFileName(t *testing.T) {
+	// test success scenario
+	successMap := map[string]time.Time{}
+	successMap["routeviews-rv6-20070101-1309.pfx2as"] = time.Date(2007, 1, 1, 13, 9, 0, 0, time.UTC)
+	successMap["routeviews-rv6-20190201-0930.pfx2as"] = time.Date(2019, 2, 1, 9, 30, 0, 0, time.UTC)
+
+	for file, time := range successMap {
+		extractedTime, err := asn.ExtractTimeFromASNFileName(file)
+		assert.Nil(t, err)
+		assert.True(t, time.Equal(*extractedTime))
+	}
+
+	// test fail scenarios
+	errStrings := []string{
+		"routeviews-rv6-2000101-1309.pfx2as",
+		"doggy",
+	}
+
+	for _, file := range errStrings {
+		extractedTime, err := asn.ExtractTimeFromASNFileName(file)
+		assert.Nil(t, extractedTime)
+		assert.Error(t, err)
+	}
+}
+
+func bToMb(b uint64) uint64 {
+	return b >> 20
+}
+
+func getAnnotatorForDay(t *testing.T, v4 bool, year, month, day int, datasetStartTime time.Time) api.Annotator {
+	geoloader.UseSpecificASNDate(&year, &month, &day)
+
+	var loader api.CachingLoader
+	if v4 {
+		loader = geoloader.ASNv4Loader(asn.LoadASNDataset)
+	} else {
+		loader = geoloader.ASNv6Loader(asn.LoadASNDataset)
+	}
+
+	err := loader.UpdateCache()
+	assert.Nil(t, err)
+
+	annotators := loader.Fetch()
+	assert.Equal(t, 1, len(annotators))
+
+	ann := annotators[0]
+	assert.True(t, ann.AnnotatorDate().Equal(datasetStartTime))
+
+	return ann
+}
+
+func assertASNData(t *testing.T, expectedASNs, gotASNs []api.ASNElement) {
+	assert.Equal(t, len(expectedASNs), len(gotASNs))
+	for idx, exp := range expectedASNs {
+		got := gotASNs[idx]
+		assert.Equal(t, exp.ASNList, got.ASNList)
+		assert.Equal(t, exp.ASNListType, got.ASNListType)
+	}
+}
+
+func dumpMemoryStats(t *testing.T) {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	t.Logf("Alloc = %v MiB", bToMb(m.Alloc))
+	t.Logf("TotalAlloc = %v MiB", bToMb(m.TotalAlloc))
+	t.Logf("Sys = %v MiB", bToMb(m.Sys))
+	t.Logf("NumGC = %v\n", m.NumGC)
+}

--- a/geoloader/geoloader.go
+++ b/geoloader/geoloader.go
@@ -75,7 +75,7 @@ type Filename string
 func loadAll(
 	cache map[Filename]api.Annotator,
 	filter func(file *storage.ObjectAttrs) error,
-	loader func(*storage.ObjectAttrs) (api.Annotator, error)
+	loader func(*storage.ObjectAttrs) (api.Annotator, error),
 	gcsPrefix string) (map[Filename]api.Annotator, error) {
 	if loader == nil {
 		return nil, ErrNoLoader

--- a/geoloader/geoloader_asn.go
+++ b/geoloader/geoloader_asn.go
@@ -1,0 +1,35 @@
+package geoloader
+
+import (
+	"regexp"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/m-lab/annotation-service/api"
+)
+
+//https://storage.cloud.google.com/downloader-mlab-sandbox/RouteViewIPv6/2010/04/routeviews-rv6-20100401-1200.pfx2as.gz?_ga=2.203048593.-1629863070.1538756657&_gac=1.91191784.1549956065.Cj0KCQiA14TjBRD_ARIsAOCmO9bXr012UcoLzU_Ndo-gPl6-wHS-RucM7cT2HaVRb8kd_-lWjbpsJZQaAuOoEALw_wcB
+var (
+	asnRegexV4 = regexp.MustCompile(`RouteViewIPv4/\d{4}/\d{2}/routeviews-(oix|rv2)-\d{8}-\d{4}\.pfx2as\.gz`)
+	asnRegexV6 = regexp.MustCompile(`RouteViewIPv6/\d{4}/\d{2}/routeviews-rv6-\d{8}-\d{4}\.pfx2as\.gz`)
+)
+
+func ASNv4Loader(
+	loader func(*storage.ObjectAttrs) (api.Annotator, error)) api.CachingLoader {
+	return newCachingLoader(
+		func(file *storage.ObjectAttrs) error {
+			return filter(file, asnRegexV4, time.Time{})
+		},
+		loader,
+		api.RouteViewPrefix)
+}
+
+func ASNv6Loader(
+	loader func(*storage.ObjectAttrs) (api.Annotator, error)) api.CachingLoader {
+	return newCachingLoader(
+		func(file *storage.ObjectAttrs) error {
+			return filter(file, asnRegexV6, time.Time{})
+		},
+		loader,
+		api.RouteViewPrefix)
+}

--- a/geoloader/geoloader_asn.go
+++ b/geoloader/geoloader_asn.go
@@ -1,6 +1,8 @@
 package geoloader
 
 import (
+	"fmt"
+	"log"
 	"regexp"
 	"time"
 
@@ -8,12 +10,34 @@ import (
 	"github.com/m-lab/annotation-service/api"
 )
 
-//https://storage.cloud.google.com/downloader-mlab-sandbox/RouteViewIPv6/2010/04/routeviews-rv6-20100401-1200.pfx2as.gz?_ga=2.203048593.-1629863070.1538756657&_gac=1.91191784.1549956065.Cj0KCQiA14TjBRD_ARIsAOCmO9bXr012UcoLzU_Ndo-gPl6-wHS-RucM7cT2HaVRb8kd_-lWjbpsJZQaAuOoEALw_wcB
 var (
-	asnRegexV4 = regexp.MustCompile(`RouteViewIPv4/\d{4}/\d{2}/routeviews-(oix|rv2)-\d{8}-\d{4}\.pfx2as\.gz`)
-	asnRegexV6 = regexp.MustCompile(`RouteViewIPv6/\d{4}/\d{2}/routeviews-rv6-\d{8}-\d{4}\.pfx2as\.gz`)
+	asnRegexV4 = regexp.MustCompile(`RouteViewIPv4/\d{4}/\d{2}/routeviews-(oix|rv2)-\d{8}-\d{4}\.pfx2as\.gz`) // matches to the IPv4 RouteView datasets
+	asnRegexV6 = regexp.MustCompile(`RouteViewIPv6/\d{4}/\d{2}/routeviews-rv6-\d{8}-\d{4}\.pfx2as\.gz`)       // matches to the IPv6 RouteView datasets
 )
 
+// Helper function for unit tests to narrow the datasets to load from GCS to a specific date.
+// The parameters are int pointers. If a parameter is nil, no filter will be used for that date part.
+func UseSpecificASNDate(year, month, day *int) {
+	yearStr := `\d{4}`
+	monthStr := `\d{2}`
+	dayStr := monthStr
+
+	if year != nil {
+		yearStr = fmt.Sprintf("%04d", *year)
+	}
+	if month != nil {
+		monthStr = fmt.Sprintf("%02d", *month)
+	}
+	if day != nil {
+		dayStr = fmt.Sprintf("%02d", *day)
+	}
+
+	asnRegexV4 = regexp.MustCompile(fmt.Sprintf(`RouteViewIPv4/%s/%s/routeviews-(oix|rv2)-%s%s%s-\d{4}\.pfx2as\.gz`, yearStr, monthStr, yearStr, monthStr, dayStr))
+	asnRegexV6 = regexp.MustCompile(fmt.Sprintf(`RouteViewIPv6/%s/%s/routeviews-rv6-%s%s%s-\d{4}\.pfx2as\.gz`, yearStr, monthStr, yearStr, monthStr, dayStr))
+	log.Printf("Date filter is set to %s%s%s", yearStr, monthStr, dayStr)
+}
+
+// ASNv4Loader should be used to load ASNv4 RouteView files
 func ASNv4Loader(
 	loader func(*storage.ObjectAttrs) (api.Annotator, error)) api.CachingLoader {
 	return newCachingLoader(
@@ -24,6 +48,7 @@ func ASNv4Loader(
 		api.RouteViewPrefix)
 }
 
+// ASNv4Loader should be used to load ASNv6 RouteView files
 func ASNv6Loader(
 	loader func(*storage.ObjectAttrs) (api.Annotator, error)) api.CachingLoader {
 	return newCachingLoader(

--- a/legacy/legacy-dataset.go
+++ b/legacy/legacy-dataset.go
@@ -90,7 +90,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"path/filepath"
 	"strconv"
 	"sync"
 	"time"
@@ -185,19 +184,12 @@ func LoadLegacyDataset(filename string, bucketname string) (*Annotator, error) {
 	return &Annotator{dataset: ann, startDate: date}, nil
 }
 
-// getGzBase extracts basename, such as "20140307T160000Z-GeoLiteCity.dat"
-// from "Maxmind/2014/03/07/20140307T160000Z-GeoLiteCity.dat.gz"
-func getGzBase(filename string) string {
-	base := filepath.Base(filename)
-	return base[0 : len(base)-3]
-}
-
 // LoadGeoliteDataset will check GCS for the matching dataset, download
 // it, process it, and load it into memory so that it can be easily
 // searched, then it will return a pointer to that GeoDataset or an error.
 func LoadGeoliteDataset(filename string, bucketname string) (*GeoIP, error) {
 	// load the legacy binary dataset
-	dataFileName := getGzBase(filename)
+	dataFileName := loader.GetGzBase(filename)
 	err := loader.UncompressGzFile(context.Background(), bucketname, filename, dataFileName)
 	if err != nil {
 		return nil, err

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -10,11 +10,20 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"path/filepath"
 	"strings"
 
 	"cloud.google.com/go/storage"
 	"golang.org/x/net/context"
 )
+
+// GetGzBase extracts basename, such as "20140307T160000Z-GeoLiteCity.dat"
+// from "Maxmind/2014/03/07/20140307T160000Z-GeoLiteCity.dat.gz"
+// KZ: moved from legacy package here
+func GetGzBase(filename string) string {
+	base := filepath.Base(filename)
+	return base[0 : len(base)-3]
+}
 
 // CreateZipReader reads a file from GCS and wraps it in a zip.Reader.
 func CreateZipReader(ctx context.Context, bucket string, bucketObj string) (*zip.Reader, error) {


### PR DESCRIPTION
To make sure that I won't impact the current codebase I decided that in the first phase I copy-paste the implementations which are needed but cannot be reused as it is right now (package private functions for building the `IPNode` list and then doing a binary search on that). I'm going to continue with externalizing this logic.

**TODOs:**
 - eliminate the 
 - the unit tests are built on the contents of `mlab-sandbox` environment -> should move the necessary files to `mlab-test`'s `downloader-mlab-test` bucket to make sure that the unit tests will work with the CI/CD tool
 - reduce the memory pressure by merging the overlapping IP ranges with the same ASNs