### PR TITLE
remove cron.sh from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@
 #
 # yamllint disable rule:line-length
 
+# CGO broken in go 1.12.2 with trusty, so this forces xenial, which should work.
+# https://github.com/golang/go/issues/31293
+dist: xenial
+
 language: go
 
 # Without this, annotator.sh fails, related to gcloud.

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,6 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-sandbox /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR annotator.yaml
-    && $TRAVIS_BUILD_DIR/cron.sh mlab-sandbox
   skip_cleanup: true
   on:
     repo: m-lab/annotation-service
@@ -98,7 +97,6 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-staging /tmp/mlab-staging.json $TRAVIS_BUILD_DIR annotator.yaml
-    && $TRAVIS_BUILD_DIR/cron.sh mlab-staging
   skip_cleanup: true
   on:
     repo: m-lab/annotation-service
@@ -109,7 +107,6 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-oti /tmp/mlab-oti.json $TRAVIS_BUILD_DIR annotator.yaml
-    && $TRAVIS_BUILD_DIR/cron.sh mlab-oti
   skip_cleanup: true
   on:
     repo: m-lab/annotation-service


### PR DESCRIPTION
Previous merge removed cron.sh, but did not remove from the travis file.  This causes all deployments to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/227)
<!-- Reviewable:end -->
