### PR TITLE
Add radius to GeolocationIP

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -30,17 +30,18 @@ var (
 // are not.
 // This is in common because it is used by the etl repository.
 type GeolocationIP struct {
-	ContinentCode string  `json:"continent_code,,omitempty" bigquery:"continent_code"` // Gives a shorthand for the continent
-	CountryCode   string  `json:"country_code,,omitempty"   bigquery:"country_code"`   // Gives a shorthand for the country
-	CountryCode3  string  `json:"country_code3,,omitempty"  bigquery:"country_code3"`  // Gives a shorthand for the country
-	CountryName   string  `json:"country_name,,omitempty"   bigquery:"country_name"`   // Name of the country
-	Region        string  `json:"region,,omitempty"         bigquery:"region"`         // Region or State within the country
-	MetroCode     int64   `json:"metro_code,,omitempty"     bigquery:"metro_code"`     // Metro code within the country
-	City          string  `json:"city,,omitempty"           bigquery:"city"`           // City within the region
-	AreaCode      int64   `json:"area_code,,omitempty"      bigquery:"area_code"`      // Area code, similar to metro code
-	PostalCode    string  `json:"postal_code,,omitempty"    bigquery:"postal_code"`    // Postal code, again similar to metro
-	Latitude      float64 `json:"latitude,,omitempty"       bigquery:"latitude"`       // Latitude
-	Longitude     float64 `json:"longitude,,omitempty"      bigquery:"longitude"`      // Longitude
+	ContinentCode    string  `json:"continent_code,,omitempty" bigquery:"continent_code"` // Gives a shorthand for the continent
+	CountryCode      string  `json:"country_code,,omitempty"   bigquery:"country_code"`   // Gives a shorthand for the country
+	CountryCode3     string  `json:"country_code3,,omitempty"  bigquery:"country_code3"`  // Gives a shorthand for the country
+	CountryName      string  `json:"country_name,,omitempty"   bigquery:"country_name"`   // Name of the country
+	Region           string  `json:"region,,omitempty"         bigquery:"region"`         // Region or State within the country
+	MetroCode        int64   `json:"metro_code,,omitempty"     bigquery:"metro_code"`     // Metro code within the country
+	City             string  `json:"city,,omitempty"           bigquery:"city"`           // City within the region
+	AreaCode         int64   `json:"area_code,,omitempty"      bigquery:"area_code"`      // Area code, similar to metro code
+	PostalCode       string  `json:"postal_code,,omitempty"    bigquery:"postal_code"`    // Postal code, again similar to metro
+	Latitude         float64 `json:"latitude,,omitempty"       bigquery:"latitude"`       // Latitude
+	Longitude        float64 `json:"longitude,,omitempty"      bigquery:"longitude"`      // Longitude
+	AccuracyRadiusKm int64   `json:"radius,,omitempty"         bigquery:"radius"`         // Accuracy Radius (geolite2 from 2018)
 }
 
 /************************************************************************

--- a/geolite2v2/geo-ip-loc-loader.go
+++ b/geolite2v2/geo-ip-loc-loader.go
@@ -27,14 +27,15 @@ var (
 
 // LocationNode defines Location databases
 type LocationNode struct {
-	GeonameID     int
-	ContinentCode string
-	CountryCode   string
-	CountryName   string
-	RegionCode    string
-	RegionName    string
-	MetroCode     int64
-	CityName      string
+	GeonameID        int
+	ContinentCode    string
+	CountryCode      string
+	CountryName      string
+	RegionCode       string
+	RegionName       string
+	MetroCode        int64
+	CityName         string
+	AccuracyRadiusKm int64
 }
 
 type locationCsvConsumer struct {
@@ -117,6 +118,15 @@ func (l *locationCsvConsumer) Consume(record []string) error {
 		}
 	}
 	lNode.CityName = record[10]
+	if len(record) > 13 {
+		lNode.AccuracyRadiusKm, err = strconv.ParseInt(record[13], 10, 64)
+		if err != nil {
+			if len(record[13]) > 0 {
+				log.Println("AccuracyRadius should be an integer:", record[13])
+				return err
+			}
+		}
+	}
 	l.locationList = append(l.locationList, lNode)
 	l.locationMap[lNode.GeonameID] = len(l.locationList) - 1
 	return nil

--- a/geolite2v2/geo-ip.go
+++ b/geolite2v2/geo-ip.go
@@ -103,17 +103,18 @@ func populateLocationData(ipNode iputils.IPNode, locationNodes []LocationNode, d
 		locNode = locationNodes[geoIPNode.LocationIndex]
 	}
 	data.Geo = &api.GeolocationIP{
-		ContinentCode: locNode.ContinentCode,
-		CountryCode:   locNode.CountryCode,
-		CountryCode3:  "", // missing from geoLite2 ?
-		CountryName:   locNode.CountryName,
-		Region:        locNode.RegionCode,
-		MetroCode:     locNode.MetroCode,
-		City:          locNode.CityName,
-		AreaCode:      0, // new geoLite2 does not have area code.
-		PostalCode:    geoIPNode.PostalCode,
-		Latitude:      geoIPNode.Latitude,
-		Longitude:     geoIPNode.Longitude,
+		ContinentCode:    locNode.ContinentCode,
+		CountryCode:      locNode.CountryCode,
+		CountryCode3:     "", // missing from geoLite2 ?
+		CountryName:      locNode.CountryName,
+		Region:           locNode.RegionCode,
+		MetroCode:        locNode.MetroCode,
+		City:             locNode.CityName,
+		AreaCode:         0, // new geoLite2 does not have area code.
+		PostalCode:       geoIPNode.PostalCode,
+		Latitude:         geoIPNode.Latitude,
+		Longitude:        geoIPNode.Longitude,
+		AccuracyRadiusKm: locNode.AccuracyRadiusKm,
 	}
 }
 

--- a/geolite2v2/geo-ip_test.go
+++ b/geolite2v2/geo-ip_test.go
@@ -32,9 +32,9 @@ func TestPopulateLocationData(t *testing.T) {
 	}{
 		{
 			node: geolite2v2.GeoIPNode{LocationIndex: 0, PostalCode: "10583"},
-			locs: []geolite2v2.LocationNode{{CityName: "Not A Real City", RegionCode: "ME"}},
+			locs: []geolite2v2.LocationNode{{CityName: "Not A Real City", RegionCode: "ME", AccuracyRadiusKm: 3}},
 			res: api.GeoData{
-				Geo:     &api.GeolocationIP{City: "Not A Real City", PostalCode: "10583", Region: "ME"},
+				Geo:     &api.GeolocationIP{City: "Not A Real City", PostalCode: "10583", Region: "ME", AccuracyRadiusKm: 3},
 				Network: nil},
 		},
 		{


### PR DESCRIPTION
This adds the accuracy radius fields and handling, so that it will be populated when available for the given date.

Updates to etl parsers may be required to propagate through to BQ.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/238)
<!-- Reviewable:end -->
