### PR TITLE
Add Annotator interface and replace GeoData with api.Annotations

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -118,8 +118,13 @@ func (as *ASData) BestASN() (int64, error) {
 // GeoData is the main struct for the geo metadata, which holds pointers to the
 // Geolocation data and the IP/ASN data. This is what we parse the JSON
 // response from the annotator into.
-// TODO - replace this with type Annotations struct.
-type GeoData struct {
+// Deprecated - please use api.Annotations
+type GeoData = Annotations
+
+// Annotations is the main struct for annotation metadata, which holds pointers to the
+// Geolocation data and the IP/ASN data. This is what we parse the JSON
+// response from the annotator into.
+type Annotations struct {
 	Geo     *GeolocationIP // Holds the geolocation data
 	Network *ASData        // Holds the associated network Autonomous System data.
 }
@@ -152,7 +157,7 @@ type RequestWrapper struct {
 type Annotator interface {
 	// Annotate populates one or more annotation fields in the GeoData object.
 	// If it fails, it will return a non-nil error and will leave the target unmodified.
-	Annotate(ip string, ann *GeoData) error
+	Annotate(ip string, ann *Annotations) error
 
 	// The date associated with the dataset.
 	AnnotatorDate() time.Time

--- a/api/api.go
+++ b/api/api.go
@@ -118,7 +118,7 @@ func (as *ASData) BestASN() (int64, error) {
 // GeoData is the main struct for the geo metadata, which holds pointers to the
 // Geolocation data and the IP/ASN data. This is what we parse the JSON
 // response from the annotator into.
-// Deprecated - please use api.Annotations
+// Deprecated: please use api.Annotations
 type GeoData = Annotations
 
 // Annotations is the main struct for annotation metadata, which holds pointers to the

--- a/api/v2/api-v2.go
+++ b/api/v2/api-v2.go
@@ -52,7 +52,6 @@ type Response struct {
 
 // Annotator defines the GetAnnotations method used for annotating.
 type Annotator interface {
-	// TODO - this function name is identical to the package function below.
 	GetAnnotations(ctx context.Context, date time.Time, ips []string) (*Response, error)
 }
 

--- a/api/v2/api-v2.go
+++ b/api/v2/api-v2.go
@@ -46,8 +46,14 @@ func NewRequest(date time.Time, ips []string) Request {
 // Response describes data returned in V2 responses (json encoded).
 type Response struct {
 	// TODO should we include additional metadata about the annotator sources?  Perhaps map of filenames?
-	AnnotatorDate time.Time               // The publication date(s) of the dataset used for the annotation
-	Annotations   map[string]*api.GeoData // Map from human readable IP address to GeoData
+	AnnotatorDate time.Time                   // The publication date(s) of the dataset used for the annotation
+	Annotations   map[string]*api.Annotations // Map from human readable IP address to GeoData
+}
+
+// Annotator defines the GetAnnotations method used for annotating.
+type Annotator interface {
+	// TODO - this function name is identical to the package function below.
+	GetAnnotations(ctx context.Context, date time.Time, ips []string) (*Response, error)
 }
 
 /*************************************************************************
@@ -130,7 +136,7 @@ var ErrMoreJSON = errors.New("JSON body not completely consumed")
 var decodeLogEvery = logx.NewLogEvery(nil, 30*time.Second)
 
 // GetAnnotations takes a url, and Request, makes remote call, and returns parsed ResponseV2
-// TODO(gfr) Should pass the annotator's request context through and use it here.
+// TODO make this unexported once we have migrated all code to use GetAnnotator()
 func GetAnnotations(ctx context.Context, url string, date time.Time, ips []string) (*Response, error) {
 	req := NewRequest(date, ips)
 	encodedData, err := json.Marshal(req)
@@ -192,4 +198,17 @@ func GetAnnotations(ctx context.Context, url string, date time.Time, ips []strin
 		decodeLogEvery.Println("Decode error:", ErrMoreJSON)
 	}
 	return &resp, nil
+}
+
+type annotator struct {
+	url string
+}
+
+func (ann annotator) GetAnnotations(ctx context.Context, date time.Time, ips []string) (*Response, error) {
+	return GetAnnotations(ctx, ann.url, date, ips)
+}
+
+// GetAnnotator returns a v2.Annotator that uses the provided url to make v2 api requests.
+func GetAnnotator(url string) Annotator {
+	return &annotator{url: url}
 }


### PR DESCRIPTION
1. Add Annotator interface, to support injection of annotator.
2. Change GeoData to Annotations, with backward compatible alias.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/245)
<!-- Reviewable:end -->
