### PR TITLE
add RequestInfo to GetAnnotations and metrics

### DIFF
--- a/api/v2/api-v2.go
+++ b/api/v2/api-v2.go
@@ -51,8 +51,10 @@ type Response struct {
 }
 
 // Annotator defines the GetAnnotations method used for annotating.
+// info is an optional string to populate Request.RequestInfo
 type Annotator interface {
-	GetAnnotations(ctx context.Context, date time.Time, ips []string) (*Response, error)
+	// TODO - make info an regular parameter instead of vararg.
+	GetAnnotations(ctx context.Context, date time.Time, ips []string, info ...string) (*Response, error)
 }
 
 /*************************************************************************
@@ -136,8 +138,11 @@ var decodeLogEvery = logx.NewLogEvery(nil, 30*time.Second)
 
 // GetAnnotations takes a url, and Request, makes remote call, and returns parsed ResponseV2
 // TODO make this unexported once we have migrated all code to use GetAnnotator()
-func GetAnnotations(ctx context.Context, url string, date time.Time, ips []string) (*Response, error) {
+func GetAnnotations(ctx context.Context, url string, date time.Time, ips []string, info ...string) (*Response, error) {
 	req := NewRequest(date, ips)
+	if len(info) > 0 {
+		req.RequestInfo = info[0]
+	}
 	encodedData, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
@@ -203,8 +208,8 @@ type annotator struct {
 	url string
 }
 
-func (ann annotator) GetAnnotations(ctx context.Context, date time.Time, ips []string) (*Response, error) {
-	return GetAnnotations(ctx, ann.url, date, ips)
+func (ann annotator) GetAnnotations(ctx context.Context, date time.Time, ips []string, info ...string) (*Response, error) {
+	return GetAnnotations(ctx, ann.url, date, ips, info...)
 }
 
 // GetAnnotator returns a v2.Annotator that uses the provided url to make v2 api requests.

--- a/api/v2/api-v2_test.go
+++ b/api/v2/api-v2_test.go
@@ -38,13 +38,13 @@ func TestDoRequest(t *testing.T) {
 	ips := []string{"8.8.8.8", "147.1.2.3"}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	resp, err := api.GetAnnotations(ctx, url, time.Now(), ips)
+	resp, err := api.GetAnnotations(ctx, url, time.Now(), ips, "reqInfo")
 	if err == nil {
 		t.Fatal("Should have timed out")
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	resp, err = api.GetAnnotations(ctx, url, time.Now(), ips)
+	resp, err = api.GetAnnotations(ctx, url, time.Now(), ips, "reqInfo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestSomeErrors(t *testing.T) {
 	ips := []string{"8.8.8.8", "147.1.2.3"}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	_, err := api.GetAnnotations(ctx, url, time.Now(), ips)
+	_, err := api.GetAnnotations(ctx, url, time.Now(), ips, "reqInfo")
 	if callCount != 1 {
 		t.Error("Should have been two calls to server.")
 	}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -249,7 +249,7 @@ func checkError(err error, w http.ResponseWriter, reqInfo string, ipCount int, l
 		default:
 			// If it isn't loading, client should probably give up instead of retrying.
 			w.WriteHeader(http.StatusInternalServerError)
-			metrics.RequestTimeHistogramUsec.WithLabelValues("", label, err.Error()).Observe(float64(time.Since(tStart).Nanoseconds()) / 1000)
+			metrics.RequestTimeHistogramUsec.WithLabelValues(reqInfo, label, err.Error()).Observe(float64(time.Since(tStart).Nanoseconds()) / 1000)
 		}
 		fmt.Fprintf(w, err.Error())
 		return true

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -30,7 +30,7 @@ var (
 				10000000,
 			},
 		},
-		[]string{"type", "detail"})
+		[]string{"source", "type", "detail"})
 	// Note the batch annotate request counted as 1 as well.
 	TotalRequests = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "annotator_Annotation_Requests_total",

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -13,7 +13,7 @@ import (
 // through the linter.
 func TestPrometheusMetrics(t *testing.T) {
 	api.RequestTimeHistogram.WithLabelValues("x")
-	metrics.RequestTimeHistogramUsec.WithLabelValues("x", "x")
+	metrics.RequestTimeHistogramUsec.WithLabelValues("x", "y", "z")
 	metrics.ErrorTotal.WithLabelValues("x")
 	metrics.RejectionCount.WithLabelValues("x")
 	promtest.LintMetrics(t)


### PR DESCRIPTION
Adds optional info field to public v2.Annotator and GetAnnotations.  Plumbs the field through RequestTime metrics.
See #246

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/247)
<!-- Reviewable:end -->
