### PR TITLE
10->80

### DIFF
--- a/annotator.yaml
+++ b/annotator.yaml
@@ -26,6 +26,7 @@ automatic_scaling:
   cool_down_period_sec: 1800
   cpu_utilization:
     target_utilization: 0.60
+  max_concurrent_requests: 80
 
 # Note: add a public port for GCE auto discovery by prometheus.
 # TODO(dev): are any values redundant or irrelevant?


### PR DESCRIPTION
As per https://cloud.google.com/appengine/docs/standard/go/config/appref#max_concurrent_requests

Hopefully will fix the RPC failure issue or at least mitigate it significantly.

80 is the max, so if we need more than that then we need more instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/254)
<!-- Reviewable:end -->
