### PR TITLE
Sandbox loader rate limit

### DIFF
--- a/annotator.yaml
+++ b/annotator.yaml
@@ -13,6 +13,8 @@ resources:
   # Instances support between [(cpu * 0.9) - 0.4, (cpu * 6.5) - 0.4]
   # Actual memory available is exposed via GAE_MEMORY_MB environment variable.
   # Service now loads ALL datasets, so it needs quite a lot of memory.
+  # With reduced loading concurrency, tested with 77 GB, which is not enough.
+  # Might be ok at 14 cpus, but keeping larger footprint for now.
   memory_gb: 129
 
   # Annotation service uses disk for loading legacy Geolite datasets.  It now loads many
@@ -49,3 +51,4 @@ liveness_check:
 
 readiness_check:
   path: "/ready"
+  app_start_timeout_sec: 600

--- a/main.go
+++ b/main.go
@@ -87,8 +87,8 @@ func main() {
 	http.HandleFunc("/updateDatasets", updateMaxmindDatasets)
 	http.HandleFunc("/ready", ready)
 	http.HandleFunc("/live", live)
-
-	handler.InitHandler()
 	log.Print("Listening on port 8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))
+
+	handler.InitHandler()
 }


### PR DESCRIPTION
This PR limits the number of concurrent dataset loads to 20.  This should reduce memory pressure during the initial loading period.
Running in sandbox, this doesn't seem to change the memory or cpu behavior, which is a bit surprising.  We may want to try reducing it further.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/255)
<!-- Reviewable:end -->
