### PR TITLE
Reduce api/v2 log spam

### DIFF
--- a/api/v2/api-v2.go
+++ b/api/v2/api-v2.go
@@ -127,9 +127,10 @@ func postWithRetry(ctx context.Context, url string, encodedData []byte) (*http.R
 			RequestTimeHistogram.WithLabelValues(resp.Status).Observe(float64(time.Since(start).Nanoseconds()) / 1e6)
 			return resp, ErrStatusNotOK
 		default:
-			log.Println("Statuscode: ", resp.StatusCode)
+			log.Println("Statuscode: ", resp.StatusCode, "url:", url)
 			RequestTimeHistogram.WithLabelValues(resp.Status).Observe(float64(time.Since(start).Nanoseconds()) / 1e6)
-			// Continue and possibly retry.
+			// TODO: Probably should continue and possibly retry, instead of returning.
+			return resp, ErrStatusNotOK
 		}
 
 		if ctx.Err() != nil {

--- a/api/v2/api-v2_test.go
+++ b/api/v2/api-v2_test.go
@@ -81,7 +81,7 @@ func TestSomeErrors(t *testing.T) {
 	defer cancel()
 	_, err := api.GetAnnotations(ctx, url, time.Now(), ips, "reqInfo")
 	if callCount != 1 {
-		t.Errorf("Should have been %d calls to server: %d", 1, callCount)
+		t.Errorf("Should have been 1 call to server: %d", callCount)
 	}
 	if err == nil {
 		t.Fatal("Should have produced an error")

--- a/api/v2/api-v2_test.go
+++ b/api/v2/api-v2_test.go
@@ -81,7 +81,7 @@ func TestSomeErrors(t *testing.T) {
 	defer cancel()
 	_, err := api.GetAnnotations(ctx, url, time.Now(), ips, "reqInfo")
 	if callCount != 1 {
-		t.Error("Should have been two calls to server.")
+		t.Errorf("Should have been %d calls to server: %d", 1, callCount)
 	}
 	if err == nil {
 		t.Fatal("Should have produced an error")


### PR DESCRIPTION
api/v2 is a bit too spammy. This reduces some of the spammy logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/263)
<!-- Reviewable:end -->
