### PR TITLE
Revert "Add new geo location subdivision fields and distinct ServerAnnotation"

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -30,26 +30,18 @@ var (
 // are not.
 // This is in common because it is used by the etl repository.
 type GeolocationIP struct {
-	ContinentCode string `json:",omitempty" bigquery:"continent_code"` // Gives a shorthand for the continent
-	CountryCode   string `json:",omitempty" bigquery:"country_code"`   // Gives a shorthand for the country
-	CountryCode3  string `json:",omitempty" bigquery:"country_code3"`  // Gives a shorthand for the country
-	CountryName   string `json:",omitempty" bigquery:"country_name"`   // Name of the country
-	Region        string `json:",omitempty" bigquery:"region"`         // Region or State within the country (MaxMind Geo1 format)
-
-	// Subdivision fields are provided by MaxMind Geo2 format and used by uuid-annotator.
-	// TODO: include fields in bigquery schemas after migrating all datatypes to uuid-annotations.
-	Subdivision1ISOCode string `json:",omitempty" bigquery:"-"`
-	Subdivision1Name    string `json:",omitempty" bigquery:"-"`
-	Subdivision2ISOCode string `json:",omitempty" bigquery:"-"`
-	Subdivision2Name    string `json:",omitempty" bigquery:"-"`
-
-	MetroCode        int64   `json:",omitempty" bigquery:"metro_code"`  // Metro code within the country
-	City             string  `json:",omitempty" bigquery:"city"`        // City within the region
-	AreaCode         int64   `json:",omitempty" bigquery:"area_code"`   // Area code, similar to metro code
-	PostalCode       string  `json:",omitempty" bigquery:"postal_code"` // Postal code, again similar to metro
-	Latitude         float64 `json:",omitempty" bigquery:"latitude"`    // Latitude
-	Longitude        float64 `json:",omitempty" bigquery:"longitude"`   // Longitude
-	AccuracyRadiusKm int64   `json:",omitempty" bigquery:"radius"`      // Accuracy Radius (geolite2 from 2018)
+	ContinentCode    string  `json:"continent_code,,omitempty" bigquery:"continent_code"` // Gives a shorthand for the continent
+	CountryCode      string  `json:"country_code,,omitempty"   bigquery:"country_code"`   // Gives a shorthand for the country
+	CountryCode3     string  `json:"country_code3,,omitempty"  bigquery:"country_code3"`  // Gives a shorthand for the country
+	CountryName      string  `json:"country_name,,omitempty"   bigquery:"country_name"`   // Name of the country
+	Region           string  `json:"region,,omitempty"         bigquery:"region"`         // Region or State within the country
+	MetroCode        int64   `json:"metro_code,,omitempty"     bigquery:"metro_code"`     // Metro code within the country
+	City             string  `json:"city,,omitempty"           bigquery:"city"`           // City within the region
+	AreaCode         int64   `json:"area_code,,omitempty"      bigquery:"area_code"`      // Area code, similar to metro code
+	PostalCode       string  `json:"postal_code,,omitempty"    bigquery:"postal_code"`    // Postal code, again similar to metro
+	Latitude         float64 `json:"latitude,,omitempty"       bigquery:"latitude"`       // Latitude
+	Longitude        float64 `json:"longitude,,omitempty"      bigquery:"longitude"`      // Longitude
+	AccuracyRadiusKm int64   `json:"radius,,omitempty"         bigquery:"radius"`         // Accuracy Radius (geolite2 from 2018)
 }
 
 /************************************************************************
@@ -137,17 +129,6 @@ type Annotations struct {
 	Geo     *GeolocationIP // Holds the geolocation data
 	Network *ASData        // Holds the associated network Autonomous System data.
 }
-
-// ServerAnnotations are server-specific fields populated by the uuid-annotator.
-type ServerAnnotations struct {
-	Site    string         // M-Lab site, i.e. lga01, yyz02, etc.
-	Machine string         // Specific M-Lab machine at a site, i.e. "mlab1", "mlab2", etc.
-	Geo     *GeolocationIP // Holds the Server geolocation data.
-	Network *ASData        // Holds the Autonomous System data.
-}
-
-// ClientAnnotations are client-specific fields populated by the uuid-annotator.
-type ClientAnnotations = Annotations
 
 /*************************************************************************
 *                       Request/Response Structs                         *

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -51,7 +51,7 @@ func TestAnnotate(t *testing.T) {
 		time string
 		res  string
 	}{
-		{"1.4.128.0", "625600", `{"Geo":{"Region":"ME","City":"Not A Real City","PostalCode":"10583","Latitude":42.1,"Longitude":-73.1},"Network":null}`},
+		{"1.4.128.0", "625600", `{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583","latitude":42.1,"longitude":-73.1},"Network":null}`},
 		{"This will be an error.", "1000", "invalid IP address"},
 	}
 	// TODO - make and use an annotator generator
@@ -227,7 +227,9 @@ func TestBatchAnnotate(t *testing.T) {
 		{
 			body: `[{"ip": "127.0.0.1", "timestamp": "2017-08-25T13:31:12.149678161-04:00"},
                     {"ip": "2620:0:1003:1008:5179:57e3:3c75:1886", "timestamp": "2017-08-25T14:32:13.149678161-04:00"}]`,
-			res: `{"127.0.0.1ov94o0":{"Geo":{"Region":"ME","City":"Not A Real City","PostalCode":"10583"},"Network":null},"2620:0:1003:1008:5179:57e3:3c75:1886ov97hp":{"Geo":{"Region":"ME","City":"Not A Real City","PostalCode":"10583"},"Network":null}}`,
+			res: `{"127.0.0.1ov94o0":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583"},"Network":null},"2620:0:1003:1008:5179:57e3:3c75:1886ov97hp":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583"},"Network":null}}`,
+			// TODO - remove alt after updating json annotations to omitempty.
+			alt: `{"127.0.0.1ov94o0":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583","latitude":0,"longitude":0},"Network":null},"2620:0:1003:1008:5179:57e3:3c75:1886ov97hp":{"Geo":{"region":"ME","city":"Not A Real City","postal_code":"10583","latitude":0,"longitude":0},"Network":null}}`,
 		},
 	}
 	// TODO - make a test utility in geolite2 package.

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -48,18 +48,18 @@ func TestInitDataset(t *testing.T) {
 		res  string
 	}{
 		// This request needs a legacy binary dataset
-		{"1.4.128.0", "1199145600", `{"Geo":{"ContinentCode":"AS","CountryCode":"TH","CountryCode3":"THA","CountryName":"Thailand","Region":"40","City":"Bangkok","Latitude":13.754,"Longitude":100.501},"Network":{"Systems":[{"ASNs":[23969]}]}}`},
+		{"1.4.128.0", "1199145600", `{"Geo":{"continent_code":"AS","country_code":"TH","country_code3":"THA","country_name":"Thailand","region":"40","city":"Bangkok","latitude":13.754,"longitude":100.501},"Network":{"Systems":[{"ASNs":[23969]}]}}`},
 		// This request needs another legacy binary dataset
 		{"1.4.128.0", "1399145600",
-			`{"Geo":{"ContinentCode":"AS","CountryCode":"TH","CountryCode3":"THA","CountryName":"Thailand","Region":"40","City":"Bangkok","Latitude":13.754,"Longitude":100.501},"Network":{"Systems":[{"ASNs":[23969]}]}}`},
+			`{"Geo":{"continent_code":"AS","country_code":"TH","country_code3":"THA","country_name":"Thailand","region":"40","city":"Bangkok","latitude":13.754,"longitude":100.501},"Network":{"Systems":[{"ASNs":[23969]}]}}`},
 		// This request needs a geolite2 dataset
 		{"1.9.128.0", "1512086400",
-			`{"Geo":{"ContinentCode":"AS","CountryCode":"MY","CountryCode3":"MYS","CountryName":"Malaysia","Region":"14","City":"Kuala Lumpur","PostalCode":"50586","Latitude":3.167,"Longitude":101.7},"Network":{"Systems":[{"ASNs":[4788]}]}}`},
+			`{"Geo":{"continent_code":"AS","country_code":"MY","country_code3":"MYS","country_name":"Malaysia","region":"14","city":"Kuala Lumpur","postal_code":"50586","latitude":3.167,"longitude":101.7},"Network":{"Systems":[{"ASNs":[4788]}]}}`},
 		// This request needs the latest dataset in the memory.
 		{"1.22.128.0", "1544400000",
-			`{"Geo":{"ContinentCode":"AS","CountryCode":"IN","CountryName":"India","Region":"HR","City":"Faridabad","Latitude":28.4333,"Longitude":77.3167},"Network":{"Systems":[{"ASNs":[45528]}]}}`},
+			`{"Geo":{"continent_code":"AS","country_code":"IN","country_name":"India","region":"HR","city":"Faridabad","latitude":28.4333,"longitude":77.3167},"Network":{"Systems":[{"ASNs":[45528]}]}}`},
 		{"2002:dced:117c::dced:117c", "1559227976",
-			`{"Geo":{"ContinentCode":"OC","CountryCode":"AU","CountryName":"Australia","Region":"VIC","City":"East Malvern","PostalCode":"3145","Latitude":-37.8833,"Longitude":145.05},"Network":{"Systems":[{"ASNs":[4804]}]}}`},
+			`{"Geo":{"continent_code":"OC","country_code":"AU","country_name":"Australia","region":"VIC","city":"East Malvern","postal_code":"3145","latitude":-37.8833,"longitude":145.05},"Network":{"Systems":[{"ASNs":[4804]}]}}`},
 	}
 	for n, test := range tests {
 		w := httptest.NewRecorder()


### PR DESCRIPTION
Reverts m-lab/annotation-service#272

Evidently some older individual etl parsers have dependencies on the json representation of the geo data. I will revert these changes to preserve existing functionality and create mirror structs for use by uuid-annotator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/273)
<!-- Reviewable:end -->
