### PR TITLE
Add support for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ provided below.
 
 MaxMind GeoLiteLatest databases include:
 
-  1. GeoLiteCity-Blocks.csv
+1. GeoLiteCity-Blocks.csv
 
     - StartIPNum IPv4
     - EndIPNum  IPv4
     - GeonameID
 
-  1. GeoLiteCity-Location.csv
+1. GeoLiteCity-Location.csv
 
     - GeonameID
     - Country Code
@@ -92,7 +92,7 @@ MaxMind GeoLiteLatest databases include:
 
 MaxMind GeoLite2 databases include:
 
-  1. GeoLite2-City-Blocks-IPv4.csv & GeoLite2-City-Blocks-IPv6.csv
+1. GeoLite2-City-Blocks-IPv4.csv & GeoLite2-City-Blocks-IPv6.csv
 
     - IP network (CIDR Format)
     - GeonameID (identifies end user location)
@@ -101,7 +101,7 @@ MaxMind GeoLite2 databases include:
     - Latitude
     - Longitude
 
-  1. GeoLite2-City-Locations-en.csv
+1. GeoLite2-City-Locations-en.csv
 
     - GeonameID
     - Continent Code
@@ -140,10 +140,38 @@ CachingLoader specifies the interface provided by loaders that load and cache a 
 1. Maintains list of loaded Annotator objects.
 1. Refreshes the list of loaded objects on demand.
 
-```
+```go
 type CachingLoader interface {
   UpdateCache() error
   Fetch() []Annotator
 }
 ```
 
+## Local Testing
+
+Install dependencies for geoip-dev and pkg-config using your local package
+manager. See .travis.yml and Dockerfile for examples.
+
+Because the default operation of the annotation service is to load *all*
+historical data, the RAM requirements are significant. Instead, for local
+testing, specify alterante date patterns for maxmind and routeview files.
+
+```sh
+go get .
+~/bin/annotation-service -maxmind_dates '2013/10/07' -routeview_dates '2013/10'
+```
+
+The annotation service supports two endpoints: `/batch_annotate` and
+`/annotate`. The `/annotate` resource accepts HTTP GET with parameters.
+
+- `since_epoch=` specifies the timestamp of the annotation.
+- `ip_addr=` specifies the IP address that should be annotated.
+
+NOTE: for local testing, only the loaded RouteView and Maxmind databases are
+used for all dates.
+
+Perform an adhoc query using `curl`:
+
+```sh
+curl 'http://localhost:8080/annotate?since_epoch=1380600000&ip_addr=67.86.65.1' | jq
+```

--- a/asn/asn_test.go
+++ b/asn/asn_test.go
@@ -33,8 +33,8 @@ func bToMb(b uint64) uint64 {
 func getAnnotatorForDay(t *testing.T, v4 bool, datasetStartTime time.Time) api.Annotator {
 	year := strconv.Itoa(datasetStartTime.Year())
 	month := fmt.Sprintf("%02d", datasetStartTime.Month())
-	day := fmt.Sprintf("%02d", datasetStartTime.Day())
-	geoloader.UseSpecificASNDateForTesting(&year, &month, &day)
+	// day := fmt.Sprintf("%02d", datasetStartTime.Day())
+	geoloader.UpdateASNDatePattern(year + "/" + month)
 
 	var loader api.CachingLoader
 	if v4 {

--- a/asn/asn_test.go
+++ b/asn/asn_test.go
@@ -33,7 +33,7 @@ func bToMb(b uint64) uint64 {
 func getAnnotatorForDay(t *testing.T, v4 bool, datasetStartTime time.Time) api.Annotator {
 	year := strconv.Itoa(datasetStartTime.Year())
 	month := fmt.Sprintf("%02d", datasetStartTime.Month())
-	// day := fmt.Sprintf("%02d", datasetStartTime.Day())
+	// NOTE: ASN patterns are limited to the first day of the month.
 	geoloader.UpdateASNDatePattern(year + "/" + month)
 
 	var loader api.CachingLoader

--- a/geolite2v2/geo-ip_test.go
+++ b/geolite2v2/geo-ip_test.go
@@ -241,8 +241,8 @@ func BenchmarkGeoLite2ipv4(b *testing.B) {
 // TODO - can this just use the standard loader now?
 func preload() error {
 	// TODO - for some reason, we are still seeing March 2018 instead of Sept 2017.
-	year, month, day := "2017", "09", "07"
-	geoloader.UseSpecificGeolite2DateForTesting(&year, &month, &day)
+	ymd := "2017/09/07"
+	geoloader.UpdateGeolitePattern(ymd)
 	g2loader := geoloader.Geolite2Loader(geolite2v2.LoadG2)
 	err := g2loader.UpdateCache()
 	if err != nil {

--- a/geolite2v2/geo-ip_test.go
+++ b/geolite2v2/geo-ip_test.go
@@ -242,7 +242,7 @@ func BenchmarkGeoLite2ipv4(b *testing.B) {
 func preload() error {
 	// TODO - for some reason, we are still seeing March 2018 instead of Sept 2017.
 	ymd := "2017/09/07"
-	geoloader.UpdateGeolitePattern(ymd)
+	geoloader.UpdateGeoliteDatePattern(ymd)
 	g2loader := geoloader.Geolite2Loader(geolite2v2.LoadG2)
 	err := g2loader.UpdateCache()
 	if err != nil {

--- a/geoloader/geoloader-asn.go
+++ b/geoloader/geoloader-asn.go
@@ -30,17 +30,17 @@ var (
 	errNeededLoadingDate = errors.New("Before needed loading date")
 )
 
-// UpdateASNDatePattern is for unit tests to narrow the datasets to load from GCS to date that can be matched to the date part regexes.
-// The parameters are string pointers. If a parameter is nil, no filter will be used for that date part.
-func UpdateASNDatePattern(ymd string) {
+// UpdateASNDatePattern sets the pattern used to match RouteView datasets to
+// load from GCS. The ym parameter is a string used as a regex pattern.
+func UpdateASNDatePattern(ym string) {
 	asnV4StartTime = time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
 	asnV6StartTime = asnV4StartTime
 
 	// NOTE: a specific YYYY/MM regex will fetch all files for that month.
 	// NOTE: we pin the regex to first of the month to conserve RAM.
-	asnRegexV4 = regexp.MustCompile(fmt.Sprintf(`RouteViewIPv4/%s/routeviews-(oix|rv2)-\d{6}01-\d{4}\.pfx2as\.gz`, ymd))
-	asnRegexV6 = regexp.MustCompile(fmt.Sprintf(`RouteViewIPv6/%s/routeviews-rv6-\d{6}01-\d{4}\.pfx2as\.gz`, ymd))
-	log.Printf("Date filter is set to %s", ymd)
+	asnRegexV4 = regexp.MustCompile(fmt.Sprintf(`RouteViewIPv4/%s/routeviews-(oix|rv2)-\d{6}01-\d{4}\.pfx2as\.gz`, ym))
+	asnRegexV6 = regexp.MustCompile(fmt.Sprintf(`RouteViewIPv6/%s/routeviews-rv6-\d{6}01-\d{4}\.pfx2as\.gz`, ym))
+	log.Printf("Date filter is set to %s", ym)
 }
 
 // asnFilterFrom returns nil if a file object's name matches the regular expression, and has a date field <= fileTime.

--- a/geoloader/geoloader-asn.go
+++ b/geoloader/geoloader-asn.go
@@ -29,29 +29,17 @@ var (
 	errNeededLoadingDate = errors.New("Before needed loading date")
 )
 
-// UseSpecificASNDateForTesting is for unit tests to narrow the datasets to load from GCS to date that can be matched to the date part regexes.
+// UpdateASNDatePattern is for unit tests to narrow the datasets to load from GCS to date that can be matched to the date part regexes.
 // The parameters are string pointers. If a parameter is nil, no filter will be used for that date part.
-func UseSpecificASNDateForTesting(yearRegex, monthRegex, dayRegex *string) {
+func UpdateASNDatePattern(ymd string) {
 	asnV4StartTime = time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
 	asnV6StartTime = asnV4StartTime
 
-	yearStr := `\d{4}`
-	monthStr := `\d{2}`
-	dayStr := `\d{2}`
-
-	if yearRegex != nil {
-		yearStr = *yearRegex
-	}
-	if monthRegex != nil {
-		monthStr = *monthRegex
-	}
-	if dayRegex != nil {
-		dayStr = *dayRegex
-	}
-
-	asnRegexV4 = regexp.MustCompile(fmt.Sprintf(`RouteViewIPv4/%s/%s/routeviews-(oix|rv2)-%s%s%s-\d{4}\.pfx2as\.gz`, yearStr, monthStr, yearStr, monthStr, dayStr))
-	asnRegexV6 = regexp.MustCompile(fmt.Sprintf(`RouteViewIPv6/%s/%s/routeviews-rv6-%s%s%s-\d{4}\.pfx2as\.gz`, yearStr, monthStr, yearStr, monthStr, dayStr))
-	log.Printf("Date filter is set to %s%s%s", yearStr, monthStr, dayStr)
+	// NOTE: a specific YYYY/MM regex will fetch all files for that month.
+	// NOTE: we pin the regex to first of the month to conserve RAM.
+	asnRegexV4 = regexp.MustCompile(fmt.Sprintf(`RouteViewIPv4/%s/routeviews-(oix|rv2)-\d{6}01-\d{4}\.pfx2as\.gz`, ymd))
+	asnRegexV6 = regexp.MustCompile(fmt.Sprintf(`RouteViewIPv6/%s/routeviews-rv6-\d{6}01-\d{4}\.pfx2as\.gz`, ymd))
+	log.Printf("Date filter is set to %s", ymd)
 }
 
 // asnFilterFrom returns nil if a file object's name matches the regular expression, and has a date field <= fileTime.

--- a/geoloader/geoloader-asn.go
+++ b/geoloader/geoloader-asn.go
@@ -20,6 +20,7 @@ const (
 )
 
 var (
+	// NOTE: we pin the regex to first of the month to conserve RAM.
 	asnRegexV4 = regexp.MustCompile(`RouteViewIPv4/\d{4}/\d{2}/routeviews-(oix|rv2)-\d{6}01-\d{4}\.pfx2as\.gz`) // matches to the IPv4 RouteView datasets (first day of each month)
 	asnRegexV6 = regexp.MustCompile(`RouteViewIPv6/\d{4}/\d{2}/routeviews-rv6-\d{6}01-\d{4}\.pfx2as\.gz`)       // matches to the IPv6 RouteView datasets (first day of each month)
 

--- a/geoloader/geoloader.go
+++ b/geoloader/geoloader.go
@@ -49,9 +49,9 @@ var (
 	errNoMatch = errors.New("Doesn't match") // TODO
 )
 
-// UpdateGeolitePattern is for unit tests to narrow the datasets to load from GCS to date that can be matched to the date part regexes.
+// UpdateGeoliteDatePattern is for unit tests to narrow the datasets to load from GCS to date that can be matched to the date part regexes.
 // The parameters are string pointers. If a parameter is nil, no filter will be used for that date part.
-func UpdateGeolitePattern(ymdRegex string) {
+func UpdateGeoliteDatePattern(ymdRegex string) {
 	geoLite2Regex = regexp.MustCompile(fmt.Sprintf(`Maxmind/%s/.*T\d{6}Z-GeoLite2-City-CSV\.zip`, ymdRegex))
 	geoLegacyRegex = regexp.MustCompile(fmt.Sprintf(`Maxmind/%s/.*T.*-GeoLiteCity.dat.*`, ymdRegex))
 	geoLegacyv6Regex = regexp.MustCompile(fmt.Sprintf(`Maxmind/%s/.*T.*-GeoLiteCityv6.dat.*`, ymdRegex))

--- a/geoloader/geoloader.go
+++ b/geoloader/geoloader.go
@@ -49,8 +49,8 @@ var (
 	errNoMatch = errors.New("Doesn't match") // TODO
 )
 
-// UpdateGeoliteDatePattern is for unit tests to narrow the datasets to load from GCS to date that can be matched to the date part regexes.
-// The parameters are string pointers. If a parameter is nil, no filter will be used for that date part.
+// UpdateGeoliteDatePattern sets the pattern used to match Maxmind datasets to
+// load from GCS. The ymdRegex parameter is a string used as a regex pattern.
 func UpdateGeoliteDatePattern(ymdRegex string) {
 	geoLite2Regex = regexp.MustCompile(fmt.Sprintf(`Maxmind/%s/.*T\d{6}Z-GeoLite2-City-CSV\.zip`, ymdRegex))
 	geoLegacyRegex = regexp.MustCompile(fmt.Sprintf(`Maxmind/%s/.*T.*-GeoLiteCity.dat.*`, ymdRegex))

--- a/geoloader/geoloader.go
+++ b/geoloader/geoloader.go
@@ -49,28 +49,14 @@ var (
 	errNoMatch = errors.New("Doesn't match") // TODO
 )
 
-// UseSpecificGeolite2DateForTesting is for unit tests to narrow the datasets to load from GCS to date that can be matched to the date part regexes.
+// UpdateGeolitePattern is for unit tests to narrow the datasets to load from GCS to date that can be matched to the date part regexes.
 // The parameters are string pointers. If a parameter is nil, no filter will be used for that date part.
-func UseSpecificGeolite2DateForTesting(yearRegex, monthRegex, dayRegex *string) {
-	yearStr := `\d{4}`
-	monthStr := `\d{2}`
-	dayStr := monthStr
-
-	if yearRegex != nil {
-		yearStr = *yearRegex
-	}
-	if monthRegex != nil {
-		monthStr = *monthRegex
-	}
-	if dayRegex != nil {
-		dayStr = *dayRegex
-	}
-
-	geoLite2Regex = regexp.MustCompile(fmt.Sprintf(`Maxmind/%s/%s/%s/%s%s%sT\d{6}Z-GeoLite2-City-CSV\.zip`, yearStr, monthStr, dayStr, yearStr, monthStr, dayStr))
-	geoLegacyRegex = regexp.MustCompile(fmt.Sprintf(`Maxmind/%s/%s/%s/%s%s%sT.*-GeoLiteCity.dat.*`, yearStr, monthStr, dayStr, yearStr, monthStr, dayStr))
-	geoLegacyv6Regex = regexp.MustCompile(fmt.Sprintf(`Maxmind/%s/%s/%s/%s%s%sT.*-GeoLiteCityv6.dat.*`, yearStr, monthStr, dayStr, yearStr, monthStr, dayStr))
+func UpdateGeolitePattern(ymdRegex string) {
+	geoLite2Regex = regexp.MustCompile(fmt.Sprintf(`Maxmind/%s/.*T\d{6}Z-GeoLite2-City-CSV\.zip`, ymdRegex))
+	geoLegacyRegex = regexp.MustCompile(fmt.Sprintf(`Maxmind/%s/.*T.*-GeoLiteCity.dat.*`, ymdRegex))
+	geoLegacyv6Regex = regexp.MustCompile(fmt.Sprintf(`Maxmind/%s/.*T.*-GeoLiteCityv6.dat.*`, ymdRegex))
 	_, file, line, _ := runtime.Caller(1)
-	log.Printf("Date filter is set to %s%s%s by %s:%d", yearStr, monthStr, dayStr, file, line)
+	log.Printf("Date filter is set to %s by %s:%d", ymdRegex, file, line)
 }
 
 // UseOnlyMarchForTest hacks the regular expressions to reduce the number of datasets for testing.

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ var (
 	minInterval    = flag.Duration("min_interval", time.Duration(18)*time.Hour, "minimum gap between 2 runs.")
 	maxInterval    = flag.Duration("max_interval", time.Duration(26)*time.Hour, "maximum gap between 2 runs.")
 
-	geoDates       = flag.String("maxmind_dates", `\d{4}/\d{2}/\d{2}`, "Regex used to match Maxmind file dates.")
+	maxmindDates   = flag.String("maxmind_dates", `\d{4}/\d{2}/\d{2}`, "Regex used to match Maxmind file dates.")
 	routeViewDates = flag.String("routeview_dates", `\d{4}/\d{2}`, "Regex used to match RouteView file dates")
 	// Create a single unified context and a cancellationMethod for said context.
 	ctx, cancelCtx = context.WithCancel(context.Background())
@@ -84,7 +84,7 @@ func main() {
 	flag.Parse()
 
 	geoloader.UpdateASNDatePattern(*routeViewDates)
-	geoloader.UpdateGeoliteDatePattern(*geoDates)
+	geoloader.UpdateGeoliteDatePattern(*maxmindDates)
 
 	runtime.SetBlockProfileRate(1000000) // 1 sample/msec
 	runtime.SetMutexProfileFraction(1000)

--- a/main.go
+++ b/main.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/m-lab/annotation-service/geoloader"
+
 	"github.com/m-lab/annotation-service/handler"
 	"github.com/m-lab/annotation-service/manager"
 	"github.com/m-lab/go/memoryless"
@@ -21,6 +23,9 @@ var (
 	updateInterval = flag.Duration("update_interval", time.Duration(24)*time.Hour, "Run the update dataset job with this frequency.")
 	minInterval    = flag.Duration("min_interval", time.Duration(18)*time.Hour, "minimum gap between 2 runs.")
 	maxInterval    = flag.Duration("max_interval", time.Duration(26)*time.Hour, "maximum gap between 2 runs.")
+
+	geoDates       = flag.String("maxmind_dates", `\d{4}/\d{2}/\d{2}`, "Regex used to match Maxmind file dates.")
+	routeViewDates = flag.String("routeview_dates", `\d{4}/\d{2}`, "Regex used to match RouteView file dates")
 	// Create a single unified context and a cancellationMethod for said context.
 	ctx, cancelCtx = context.WithCancel(context.Background())
 )
@@ -77,6 +82,9 @@ func init() {
 
 func main() {
 	flag.Parse()
+
+	geoloader.UpdateASNDatePattern(*routeViewDates)
+	geoloader.UpdateGeolitePattern(*geoDates)
 
 	runtime.SetBlockProfileRate(1000000) // 1 sample/msec
 	runtime.SetMutexProfileFraction(1000)

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 	flag.Parse()
 
 	geoloader.UpdateASNDatePattern(*routeViewDates)
-	geoloader.UpdateGeolitePattern(*geoDates)
+	geoloader.UpdateGeoliteDatePattern(*geoDates)
 
 	runtime.SetBlockProfileRate(1000000) // 1 sample/msec
 	runtime.SetMutexProfileFraction(1000)

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -38,10 +38,10 @@ func TestInitDataset(t *testing.T) {
 
 	// Make the dataset filters much more restrictive to prevent OOM and make test faster.
 	//geoloader.UseOnlyMarchForTest()
-	year, month, day := "(2018|2017|2015|2014)", "03", "(07|08)"
-	geoloader.UseSpecificGeolite2DateForTesting(&year, &month, &day)
-	year, month, day = "2018", "03", "(01|08)"
-	geoloader.UseSpecificASNDateForTesting(&year, &month, &day)
+	ymd := "(2018|2017|2015|2014)/03/(07|08)"
+	geoloader.UpdateGeolitePattern(ymd)
+	ymd = "2018/03/(01|08)"
+	geoloader.UpdateASNDatePattern(ymd)
 
 	// Load the small directory.
 	manager.MustUpdateDirectory()

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -40,8 +40,8 @@ func TestInitDataset(t *testing.T) {
 	//geoloader.UseOnlyMarchForTest()
 	ymd := "(2018|2017|2015|2014)/03/(07|08)"
 	geoloader.UpdateGeoliteDatePattern(ymd)
-	ymd = "2018/03/(01|08)"
-	geoloader.UpdateASNDatePattern(ymd)
+	ym := "2018/03"
+	geoloader.UpdateASNDatePattern(ym)
 
 	// Load the small directory.
 	manager.MustUpdateDirectory()

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -39,7 +39,7 @@ func TestInitDataset(t *testing.T) {
 	// Make the dataset filters much more restrictive to prevent OOM and make test faster.
 	//geoloader.UseOnlyMarchForTest()
 	ymd := "(2018|2017|2015|2014)/03/(07|08)"
-	geoloader.UpdateGeolitePattern(ymd)
+	geoloader.UpdateGeoliteDatePattern(ymd)
 	ymd = "2018/03/(01|08)"
 	geoloader.UpdateASNDatePattern(ymd)
 


### PR DESCRIPTION
This change adds support for specifying alternate ASN and Maxmind date patterns for local development. This includes two new flags to the annotation-service for `-routeview_dates` and `-maxmind_dates`. This is to overcome the default behavior which is to load *all* historical archives in RAM.

Testing: ran using Local Development steps in README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/280)
<!-- Reviewable:end -->
