### PR TITLE
Add support for setting Missing:true when appropriate

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -223,6 +223,7 @@ func AnnotateV2(date time.Time, ips []string, reqInfo string) (v2.Response, erro
 				metrics.ErrorTotal.WithLabelValues("Annotate Error").Inc()
 
 				// We are trying to debug error propagation.  So logging errors here to help with that.
+				fmt.Println("ERROR:", err)
 				v2errorLogger.Println(err)
 			}
 			continue

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -319,6 +319,17 @@ func handleOld(w http.ResponseWriter, tStart time.Time, jsonBuffer []byte) {
 	}
 	for _, anno := range responseMap {
 		trackMissingResponses(anno)
+		// Set Missing=true for empty results.
+		if anno.Geo == nil {
+			anno.Geo = &api.GeolocationIP{
+				Missing: true,
+			}
+		}
+		if anno.Network == nil {
+			anno.Network = &api.ASData{
+				Missing: true,
+			}
+		}
 	}
 	encodedResult, err := json.Marshal(responseMap)
 	if checkError(err, w, "old", len(dataSlice), "", tStart) {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -223,7 +223,6 @@ func AnnotateV2(date time.Time, ips []string, reqInfo string) (v2.Response, erro
 				metrics.ErrorTotal.WithLabelValues("Annotate Error").Inc()
 
 				// We are trying to debug error propagation.  So logging errors here to help with that.
-				fmt.Println("ERROR:", err)
 				v2errorLogger.Println(err)
 			}
 			continue

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -63,6 +63,18 @@ func Annotate(w http.ResponseWriter, r *http.Request) {
 
 	trackMissingResponses(&result)
 
+	// Set Missing=true for empty results.
+	if result.Geo == nil {
+		result.Geo = &api.GeolocationIP{
+			Missing: true,
+		}
+	}
+	if result.Network == nil {
+		result.Network = &api.ASData{
+			Missing: true,
+		}
+	}
+
 	encodedResult, err := json.Marshal(result)
 	if checkError(err, w, "", 1, "single", tStart) {
 		return
@@ -214,6 +226,16 @@ func AnnotateV2(date time.Time, ips []string, reqInfo string) (v2.Response, erro
 				v2errorLogger.Println(err)
 			}
 			continue
+		}
+		if annotation.Geo == nil {
+			annotation.Geo = &api.GeolocationIP{
+				Missing: true,
+			}
+		}
+		if annotation.Network == nil {
+			annotation.Network = &api.ASData{
+				Missing: true,
+			}
 		}
 		responseMap[ips[i]] = &annotation
 	}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -229,7 +229,7 @@ func TestBatchAnnotate(t *testing.T) {
 		{
 			body: `[{"ip": "127.0.0.1", "timestamp": "2017-08-25T13:31:12.149678161-04:00"},
                     {"ip": "2620:0:1003:1008:5179:57e3:3c75:1886", "timestamp": "2017-08-25T14:32:13.149678161-04:00"}]`,
-			res: `{"127.0.0.1ov94o0":{"Geo":{"region":"ME","Subdivision1ISOCode":"ME","city":"Not A Real City","postal_code":"10583"},"Network":null},"2620:0:1003:1008:5179:57e3:3c75:1886ov97hp":{"Geo":{"region":"ME","Subdivision1ISOCode":"ME","city":"Not A Real City","postal_code":"10583"},"Network":null}}`,
+			res: `{"127.0.0.1ov94o0":{"Geo":{"region":"ME","Subdivision1ISOCode":"ME","city":"Not A Real City","postal_code":"10583"},"Network":{"Missing":true}},"2620:0:1003:1008:5179:57e3:3c75:1886ov97hp":{"Geo":{"region":"ME","Subdivision1ISOCode":"ME","city":"Not A Real City","postal_code":"10583"},"Network":{"Missing":true}}}`,
 		},
 	}
 	// TODO - make a test utility in geolite2 package.

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -237,18 +237,18 @@ func TestBatchAnnotate(t *testing.T) {
 		{
 			// Do not use directory composit annotator to generate an annotation error and return empty result.
 			body: `{"RequestType": "Annotate v2.0", "Date": "2013-10-01T00:00:00Z", "IPs": ["227.86.65.1"]}`,
-			res:  `{"AnnotatorDate":"2021-04-12T20:00:00-04:00","Annotations":{}}`,
+			res:  `{"AnnotatorDate":"2020-01-01T00:00:00Z","Annotations":{}}`,
 		},
 		{
 			// Use directory composit annotator to generate missing annotation values.
 			body:   `{"RequestType": "Annotate v2.0", "Date": "2013-10-01T00:00:00Z", "IPs": ["227.86.65.1"]}`,
-			res:    `{"AnnotatorDate":"2021-04-12T20:00:00-04:00","Annotations":{"227.86.65.1":{"Geo":{"Missing":true},"Network":{"Missing":true}}}}`,
+			res:    `{"AnnotatorDate":"2020-01-01T00:00:00Z","Annotations":{"227.86.65.1":{"Geo":{"Missing":true},"Network":{"Missing":true}}}}`,
 			useDir: true,
 		},
 	}
 	// TODO - make a test utility in geolite2 package.
 	ann := &geolite2v2.GeoDataset{
-		Start: time.Now().Truncate(24 * time.Hour),
+		Start: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 		IP4Nodes: []geolite2v2.GeoIPNode{
 			{
 				BaseIPNode: iputils.BaseIPNode{

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -51,7 +51,7 @@ func TestAnnotate(t *testing.T) {
 		time string
 		res  string
 	}{
-		{"1.4.128.0", "625600", `{"Geo":{"region":"ME","Subdivision1ISOCode":"ME","city":"Not A Real City","postal_code":"10583","latitude":42.1,"longitude":-73.1},"Network":null}`},
+		{"1.4.128.0", "625600", `{"Geo":{"region":"ME","Subdivision1ISOCode":"ME","city":"Not A Real City","postal_code":"10583","latitude":42.1,"longitude":-73.1},"Network":{"Missing":true}}`},
 		{"This will be an error.", "1000", "invalid IP address"},
 	}
 	// TODO - make and use an annotator generator


### PR DESCRIPTION
This change modifies the return type of requests where previously the Geo or Network fields would have been JSON `null`.

This change instead sets the field `Missing=true`. This differentiates annotations that failed due to a problem connecting to the annotation-service from annotations that were positively identified as not being found in the available databases.

Testing: ad-hoc using local build of annotation-service and manual queries below.
Testing: running in sandbox...

```
$ ~/bin/annotation-service  -maxmind_dates '2018/10/01' -routeview_dates '2018/10'  -logx.debug=true &
...

$ curl -s --data '{}' -XPOST 'http://localhost:8080/annotate?since_epoch=1480600000&ip_addr=227.86.65.1' | jq
{
  "Geo": {
    "Missing": true
  },
  "Network": {
    "Missing": true
  }
}

$ curl -s --data '{"RequestType": "Annotate v2.0", "Date": "2013-10-01T00:00:00Z", "IPs": ["227.86.65.1", "27.86.65.1", "67.86.65.1"]}' -XPOST 'http://localhost:8080/batch_annotate' | jq
{
  "AnnotatorDate": "2018-10-01T00:00:00Z",
  "Annotations": {
    "227.86.65.1": {
      "Geo": {
        "Missing": true
      },
      "Network": {
        "Missing": true
      }
    },
    "27.86.65.1": {
      "Geo": {
        "continent_code": "AS",
        "country_code": "JP",
        "country_name": "Japan",
        "latitude": 35.69,
        "longitude": 139.69
      },
      "Network": {
        "CIDR": "27.80.0.0/12",
        "ASNumber": 2516,
        "ASName": "KDDI CORPORATION",
        "Systems": [
          {
            "ASNs": [
              2516
            ]
          }
        ]
      }
    },
    "67.86.65.1": {
      "Geo": {
        "continent_code": "NA",
        "country_code": "US",
        "country_name": "United States",
        "region": "NJ",
        "Subdivision1ISOCode": "NJ",
        "Subdivision1Name": "New Jersey",
        "metro_code": 501,
        "city": "Morris Plains",
        "postal_code": "07950",
        "latitude": 40.8447,
        "longitude": -74.4781
      },
      "Network": {
        "CIDR": "67.80.0.0/13",
        "ASNumber": 6128,
        "ASName": "Cablevision Systems Corp.",
        "Systems": [
          {
            "ASNs": [
              6128
            ]
          }
        ]
      }
    }
  }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/283)
<!-- Reviewable:end -->
