### PR TITLE
Import site package as-is from m-lab/etl

### DIFF
--- a/site/site.go
+++ b/site/site.go
@@ -1,0 +1,157 @@
+// Package site provides site annotations.
+package site
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"log"
+	"time"
+
+	"github.com/m-lab/go/content"
+	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/rtx"
+	uuid "github.com/m-lab/uuid-annotator/annotator"
+)
+
+var (
+	// For example of how siteinfo is loaded on production servers, see
+	// https://github.com/m-lab/k8s-support/blob/ff5b53faef7828d11d45c2a4f27d53077ddd080c/k8s/daemonsets/templates.jsonnet#L350
+	siteinfo        = flagx.URL{}
+	siteinfoRetired = flagx.URL{}
+	globalAnnotator *annotator
+)
+
+func init() {
+	flag.Var(&siteinfo, "siteinfo.url", "The URL for the Siteinfo JSON file containing server location and ASN metadata. gs:// and file:// schemes accepted.")
+	flag.Var(&siteinfoRetired, "siteinfo.retired-url", "The URL for the Siteinfo retired JSON file. gs:// and file:// schemes accepted.")
+	globalAnnotator = nil
+}
+
+// Annotate adds site annotation for a site/machine
+func Annotate(site, machine string, server *uuid.ServerAnnotations) {
+	if globalAnnotator != nil {
+		globalAnnotator.Annotate(site, machine, server)
+	}
+}
+
+// LoadFrom loads the site annotation source from the provider.
+func LoadFrom(ctx context.Context, js content.Provider, retiredJS content.Provider) error {
+	globalAnnotator = &annotator{
+		siteinfoSource:        js,
+		siteinfoRetiredSource: retiredJS,
+		sites:                 make(map[string]uuid.ServerAnnotations, 200),
+	}
+	err := globalAnnotator.load(ctx)
+	log.Println(len(globalAnnotator.sites), "sites loaded")
+	return err
+}
+
+// MustLoad loads the site annotations source and will call log.Fatal if the
+// loading fails.
+func MustLoad(timeout time.Duration) {
+	err := Load(timeout)
+	rtx.Must(err, "Could not load annotation db")
+}
+
+// Load loads the site annotations source. Will try at least once, retry up to
+// timeout and return an error if unsuccessful.
+func Load(timeout time.Duration) error {
+	js, err := content.FromURL(context.Background(), siteinfo.URL)
+	rtx.Must(err, "Invalid server annotations URL", siteinfo.URL.String())
+
+	retiredJS, err := content.FromURL(context.Background(), siteinfoRetired.URL)
+	rtx.Must(err, "Invalid retired server annotations URL", siteinfoRetired.URL.String())
+
+	// When annotations are read via HTTP, which is the default, a timeout of
+	// 1 minute is used for the GET request.
+	// The timeout specified here must be > 1 * time.Minute for the retry loop
+	// to make sense.
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	for ; ctx.Err() == nil; time.Sleep(time.Second) {
+		err = LoadFrom(context.Background(), js, retiredJS)
+		if err == nil {
+			break
+		}
+	}
+	return err
+}
+
+// annotator stores the annotations, and provides Annotate method.
+type annotator struct {
+	siteinfoSource        content.Provider
+	siteinfoRetiredSource content.Provider
+	// Each site has a single ServerAnnotations struct, which
+	// is later customized for each machine.
+	sites map[string]uuid.ServerAnnotations
+}
+
+// missing is used if annotation is requested for a non-existant server.
+var missing = uuid.ServerAnnotations{
+	Geo: &uuid.Geolocation{
+		Missing: true,
+	},
+	Network: &uuid.Network{
+		Missing: true,
+	},
+}
+
+// Annotate annotates the server with the approprate annotations.
+func (sa *annotator) Annotate(site, machine string, server *uuid.ServerAnnotations) {
+	if server == nil {
+		return
+	}
+
+	server.Machine = machine
+	server.Site = site
+	s, ok := sa.sites[site]
+	if !ok {
+		server.Geo = missing.Geo
+		server.Network = missing.Network
+		return
+	}
+	server.Geo = s.Geo
+	server.Network = s.Network
+}
+
+// load loads siteinfo dataset and returns them.
+func (sa *annotator) load(ctx context.Context) error {
+	// siteinfoAnnotation struct is used for parsing the json annotation source.
+	type siteinfoAnnotation struct {
+		Site    string
+		Network struct {
+			IPv4 string
+			IPv6 string
+		}
+		Annotation uuid.ServerAnnotations
+	}
+
+	js, err := sa.siteinfoSource.Get(ctx)
+	if err != nil {
+		return err
+	}
+	var s []siteinfoAnnotation
+	err = json.Unmarshal(js, &s)
+	if err != nil {
+		return err
+	}
+	// Read the retired sites JSON file, and merge it with the current sites.
+	retiredJS, err := sa.siteinfoRetiredSource.Get(ctx)
+	if err != nil {
+		return err
+	}
+	var retired []siteinfoAnnotation
+	err = json.Unmarshal(retiredJS, &retired)
+	if err != nil {
+		return err
+	}
+	s = append(s, retired...)
+	for _, ann := range s {
+		// Machine should always be empty, filled in later.
+		ann.Annotation.Machine = ""
+		sa.sites[ann.Annotation.Site] = ann.Annotation // Copy out of array.
+	}
+	return nil
+}

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -1,0 +1,168 @@
+package site_test
+
+import (
+	"context"
+	"flag"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-test/deep"
+	"github.com/m-lab/etl/site"
+	"github.com/m-lab/go/content"
+	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/osx"
+	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/uuid-annotator/annotator"
+)
+
+type badProvider struct {
+	err error
+}
+
+func (b badProvider) Get(_ context.Context) ([]byte, error) {
+	return nil, b.err
+}
+
+var (
+	localRawfile content.Provider
+	corruptFile  content.Provider
+	retiredFile  content.Provider
+)
+
+func setUp() {
+	u, err := url.Parse("file:testdata/annotations.json")
+	rtx.Must(err, "Could not parse URL")
+	localRawfile, err = content.FromURL(context.Background(), u)
+	rtx.Must(err, "Could not create content.Provider")
+
+	u, err = url.Parse("file:testdata/corrupt-annotations.json")
+	rtx.Must(err, "Could not parse URL")
+	corruptFile, err = content.FromURL(context.Background(), u)
+	rtx.Must(err, "Could not create content.Provider")
+
+	u, err = url.Parse("file:testdata/retired-annotations.json")
+	rtx.Must(err, "Could not parse URL")
+	retiredFile, err = content.FromURL(context.Background(), u)
+	rtx.Must(err, "Could not create content.Provider")
+}
+
+func TestBasic(t *testing.T) {
+	setUp()
+	ctx := context.Background()
+	site.LoadFrom(ctx, localRawfile, retiredFile)
+	missingServerAnn := annotator.ServerAnnotations{
+		Machine: "foo",
+		Site:    "bar",
+		Geo: &annotator.Geolocation{
+			Missing: true,
+		},
+		Network: &annotator.Network{
+			Missing: true,
+		},
+	}
+
+	defaultServerAnn := annotator.ServerAnnotations{
+		Machine: "mlab1",
+		Site:    "lga03",
+		Geo: &annotator.Geolocation{
+			ContinentCode: "NA",
+			CountryCode:   "US",
+			City:          "New York",
+			Latitude:      40.7667,
+			Longitude:     -73.8667,
+		},
+		Network: &annotator.Network{
+			ASNumber: 6453,
+			ASName:   "TATA COMMUNICATIONS (AMERICA) INC",
+			Systems: []annotator.System{
+				{ASNs: []uint32{6453}},
+			},
+		},
+	}
+
+	retiredServerann := annotator.ServerAnnotations{
+		Machine: "mlab1",
+		Site:    "acc01",
+		Geo: &annotator.Geolocation{
+			ContinentCode: "AF",
+			CountryCode:   "GH",
+			City:          "Accra",
+			Latitude:      5.606,
+			Longitude:     -0.1681,
+		},
+		Network: &annotator.Network{
+			ASNumber: 30997,
+			ASName:   "Ghana Internet Exchange Association",
+			Systems: []annotator.System{
+				{ASNs: []uint32{30997}},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		site, machine string
+		want          annotator.ServerAnnotations
+	}{
+		{
+			name:    "success",
+			site:    "lga03",
+			machine: "mlab1",
+			want:    defaultServerAnn,
+		},
+		{
+			name:    "success-retired-site",
+			site:    "acc01",
+			machine: "mlab1",
+			want:    retiredServerann,
+		},
+		{
+			name:    "missing",
+			site:    "bar",
+			machine: "foo",
+			want:    missingServerAnn,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ann := annotator.ServerAnnotations{}
+			site.Annotate(tt.site, tt.machine, &ann)
+			if diff := deep.Equal(ann, tt.want); diff != nil {
+				t.Errorf("Annotate() failed; %s", strings.Join(diff, "\n"))
+			}
+		})
+	}
+}
+
+func TestMustLoad(t *testing.T) {
+	cleanupURL := osx.MustSetenv("SITEINFO_URL", "file:testdata/annotations.json")
+	defer cleanupURL()
+	cleanupRetiredURL := osx.MustSetenv("SITEINFO_RETIRED_URL", "file:testdata/retired-annotations.json")
+	defer cleanupRetiredURL()
+	flag.Parse()
+	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from environment variables")
+
+	site.MustLoad(5 * time.Second)
+}
+
+func TestNilServer(t *testing.T) {
+	setUp()
+	ctx := context.Background()
+	err := site.LoadFrom(ctx, localRawfile, retiredFile)
+	if err != nil {
+		t.Error(err)
+	}
+	// Should not panic!  Nothing else to check.
+	site.Annotate("lga03", "mlab1", nil)
+}
+
+func TestCorrupt(t *testing.T) {
+	setUp()
+	ctx := context.Background()
+	err := site.LoadFrom(ctx, corruptFile, corruptFile)
+	if err == nil {
+		t.Error("Expected load error")
+	}
+}

--- a/site/testdata/annotations.json
+++ b/site/testdata/annotations.json
@@ -1,0 +1,95 @@
+[
+   {
+      "Annotation": {
+         "Geo": {
+            "City": "New York",
+            "ContinentCode": "NA",
+            "CountryCode": "US",
+            "Latitude": 40.7667,
+            "Longitude": -73.8667,
+            "State": "NY"
+         },
+         "Network": {
+            "ASName": "TATA COMMUNICATIONS (AMERICA) INC",
+            "ASNumber": 6453,
+            "Systems": [
+               {
+                  "ASNs": [
+                     6453
+                  ]
+               }
+            ]
+         },
+         "Site": "lga03"
+      },
+      "Name": "lga03",
+      "Network": {
+         "IPv4": "64.86.148.128/26",
+         "IPv6": "2001:5a0:4300::/64"
+      }
+   },
+   {
+      "Annotation": {
+         "Geo": {
+            "City": "New York"
+         },
+         "Network": {
+            "ASName": "TATA COMMUNICATIONS (AMERICA) INC"
+         },
+         "Site": "six02"
+      },
+      "Name": "six02",
+      "Network": {
+         "IPv4": "",
+         "IPv6": "2001:5a0:4300::/64"
+      }
+   },
+   {
+      "Annotation": {
+         "Geo": {
+            "City": "New York"
+         },
+         "Network": {
+            "ASName": "TATA COMMUNICATIONS (AMERICA) INC"
+         },
+         "Site": "six01"
+      },
+      "Name": "six01",
+      "Network": {
+         "IPv4": "64.86.148.128/26",
+         "IPv6": ""
+      }
+   },
+   {
+      "Annotation": {
+         "Geo": {
+            "City": "New York"
+         },
+         "Network": {
+            "ASName": "TATA COMMUNICATIONS (AMERICA) INC"
+         },
+         "Site": "bad04"
+      },
+      "Name": "bad04",
+      "Network": {
+         "IPv4": "this-is-not-a-subnet/26",
+         "IPv6": "2001:5a0:4300::/64"
+      }
+   },
+   {
+      "Annotation": {
+         "Geo": {
+            "City": "New York"
+         },
+         "Network": {
+            "ASName": "TATA COMMUNICATIONS (AMERICA) INC"
+         },
+         "Site": "bad06"
+      },
+      "Name": "bad06",
+      "Network": {
+         "IPv4": "64.86.148.128/26",
+         "IPv6": "this-is-not-a-subnet/64"
+      }
+   }
+]

--- a/site/testdata/corrupt-annotations.json
+++ b/site/testdata/corrupt-annotations.json
@@ -1,0 +1,11 @@
+[
+   {
+      "Geo": {
+         "City": "New York",
+         "ContinentCode": "NA",
+         "CountryCode": "US",
+         "Latitude": 40.7667,
+         "Longitude": -73.8667,
+         "State": "NY"
+      },
+   // INCOMPLETE AND CORRUPT JSON.

--- a/site/testdata/retired-annotations.json
+++ b/site/testdata/retired-annotations.json
@@ -1,0 +1,60 @@
+[
+    {
+       "Annotation": {
+          "Geo": {
+             "City": "Accra",
+             "ContinentCode": "AF",
+             "CountryCode": "GH",
+             "Latitude": 5.606,
+             "Longitude": -0.1681,
+             "State": ""
+          },
+          "Network": {
+             "ASName": "Ghana Internet Exchange Association",
+             "ASNumber": 30997,
+             "Systems": [
+                {
+                   "ASNs": [
+                      30997
+                   ]
+                }
+             ]
+          },
+          "Site": "acc01"
+       },
+       "Name": "acc01",
+       "Network": {
+          "IPv4": "196.201.2.192/26",
+          "IPv6": ""
+       }
+    },
+    {
+        "Annotation": {
+           "Geo": {
+              "City": "Accra",
+              "ContinentCode": "AF",
+              "CountryCode": "GH",
+              "Latitude": 5.606,
+              "Longitude": -0.1681,
+              "State": ""
+           },
+           "Network": {
+              "ASName": "Ghana Internet Exchange Association",
+              "ASNumber": 30997,
+              "Systems": [
+                 {
+                    "ASNs": [
+                       30997
+                    ]
+                 }
+              ]
+           },
+           "Site": "acc02"
+        },
+        "Name": "acc02",
+        "Network": {
+           "IPv4": "196.49.14.192/26",
+           "IPv6": ""
+        }
+     }
+]


### PR DESCRIPTION
This PR copies the site package from m-lab/etl to m-lab/annotation-service since it will be the main (and, for now, only)  user of that package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/284)
<!-- Reviewable:end -->
