### PR TITLE
Add support for site annotations to the site package

### DIFF
--- a/site/site.go
+++ b/site/site.go
@@ -172,7 +172,6 @@ func (sa *annotator) load(ctx context.Context) error {
 		}
 		_, _, err := net.ParseCIDR(ann.Network.IPv4)
 		if err != nil {
-			fmt.Printf("Skipping %s (%s)\n", ann.Network.IPv4, ann.Annotation.Site)
 			continue
 		}
 
@@ -180,7 +179,6 @@ func (sa *annotator) load(ctx context.Context) error {
 		if ann.Network.IPv6 != "" {
 			_, _, err = net.ParseCIDR(ann.Network.IPv6)
 			if err != nil {
-				fmt.Printf("Skipping %s (%s)\n", ann.Network.IPv6, ann.Annotation.Site)
 				continue
 			}
 			sa.networks[ann.Network.IPv6] = ann.Annotation
@@ -191,8 +189,5 @@ func (sa *annotator) load(ctx context.Context) error {
 		sa.sites[ann.Annotation.Site] = ann.Annotation // Copy out of array.
 	}
 
-	for k, v := range sa.networks {
-		fmt.Printf("%s -> %s\n", k, v.Site)
-	}
 	return nil
 }

--- a/site/site.go
+++ b/site/site.go
@@ -109,7 +109,7 @@ func (sa *annotator) Annotate(ip string, server *uuid.ServerAnnotations) {
 	}
 
 	// Find CIDR corresponding to the provided ip.
-	// All of our subnets are /26 if IPv6, /64 if IPv6.
+	// All of our subnets are /26 if IPv4, /64 if IPv6.
 	var cidr string
 	if parsedIP.To4() == nil {
 		mask := net.CIDRMask(64, 128)

--- a/site/site.go
+++ b/site/site.go
@@ -43,7 +43,6 @@ func LoadFrom(ctx context.Context, js content.Provider, retiredJS content.Provid
 		siteinfoSource:        js,
 		siteinfoRetiredSource: retiredJS,
 		networks:              make(map[string]uuid.ServerAnnotations, 400),
-		sites:                 make(map[string]uuid.ServerAnnotations, 200),
 	}
 	err := globalAnnotator.load(ctx)
 	log.Println(len(globalAnnotator.sites), "sites loaded")
@@ -185,8 +184,6 @@ func (sa *annotator) load(ctx context.Context) error {
 		}
 
 		sa.networks[ann.Network.IPv4] = ann.Annotation
-		// TODO: remove.
-		sa.sites[ann.Annotation.Site] = ann.Annotation // Copy out of array.
 	}
 
 	return nil

--- a/site/site.go
+++ b/site/site.go
@@ -103,6 +103,10 @@ var missing = uuid.ServerAnnotations{
 
 // Annotate annotates the server with the appropriate annotations.
 func (sa *annotator) Annotate(ip string, server *uuid.ServerAnnotations) {
+	if server == nil {
+		return
+	}
+
 	parsedIP := net.ParseIP(ip)
 	if parsedIP == nil {
 		return
@@ -171,6 +175,8 @@ func (sa *annotator) load(ctx context.Context) error {
 		}
 		_, _, err := net.ParseCIDR(ann.Network.IPv4)
 		if err != nil {
+			log.Printf("Found incorrect IPv4 in siteinfo: %s\n",
+				ann.Network.IPv4)
 			continue
 		}
 
@@ -178,6 +184,8 @@ func (sa *annotator) load(ctx context.Context) error {
 		if ann.Network.IPv6 != "" {
 			_, _, err = net.ParseCIDR(ann.Network.IPv6)
 			if err != nil {
+				log.Printf("Found incorrect IPv6 in siteinfo: %s\n",
+					ann.Network.IPv6)
 				continue
 			}
 			sa.networks[ann.Network.IPv6] = ann.Annotation

--- a/site/site.go
+++ b/site/site.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
+	"net"
 	"time"
 
 	"github.com/m-lab/go/content"
@@ -29,9 +31,9 @@ func init() {
 }
 
 // Annotate adds site annotation for a site/machine
-func Annotate(site, machine string, server *uuid.ServerAnnotations) {
+func Annotate(ip string, server *uuid.ServerAnnotations) {
 	if globalAnnotator != nil {
-		globalAnnotator.Annotate(site, machine, server)
+		globalAnnotator.Annotate(ip, server)
 	}
 }
 
@@ -40,6 +42,7 @@ func LoadFrom(ctx context.Context, js content.Provider, retiredJS content.Provid
 	globalAnnotator = &annotator{
 		siteinfoSource:        js,
 		siteinfoRetiredSource: retiredJS,
+		networks:              make(map[string]uuid.ServerAnnotations, 400),
 		sites:                 make(map[string]uuid.ServerAnnotations, 200),
 	}
 	err := globalAnnotator.load(ctx)
@@ -85,7 +88,8 @@ type annotator struct {
 	siteinfoRetiredSource content.Provider
 	// Each site has a single ServerAnnotations struct, which
 	// is later customized for each machine.
-	sites map[string]uuid.ServerAnnotations
+	sites    map[string]uuid.ServerAnnotations
+	networks map[string]uuid.ServerAnnotations
 }
 
 // missing is used if annotation is requested for a non-existant server.
@@ -98,22 +102,29 @@ var missing = uuid.ServerAnnotations{
 	},
 }
 
-// Annotate annotates the server with the approprate annotations.
-func (sa *annotator) Annotate(site, machine string, server *uuid.ServerAnnotations) {
-	if server == nil {
+// Annotate annotates the server with the appropriate annotations.
+func (sa *annotator) Annotate(ip string, server *uuid.ServerAnnotations) {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
 		return
 	}
 
-	server.Machine = machine
-	server.Site = site
-	s, ok := sa.sites[site]
-	if !ok {
-		server.Geo = missing.Geo
-		server.Network = missing.Network
-		return
+	// Find CIDR corresponding to the provided ip.
+	// All of our subnets are /26 if IPv6, /64 if IPv6.
+	var cidr string
+	if parsedIP.To4() == nil {
+		mask := net.CIDRMask(64, 128)
+		cidr = fmt.Sprintf("%s/64", parsedIP.Mask(mask))
+	} else {
+		mask := net.CIDRMask(26, 32)
+		cidr = fmt.Sprintf("%s/26", parsedIP.Mask(mask))
 	}
-	server.Geo = s.Geo
-	server.Network = s.Network
+
+	if ann, ok := sa.networks[cidr]; ok {
+		*server = ann
+	} else {
+		*server = missing
+	}
 }
 
 // load loads siteinfo dataset and returns them.
@@ -151,7 +162,37 @@ func (sa *annotator) load(ctx context.Context) error {
 	for _, ann := range s {
 		// Machine should always be empty, filled in later.
 		ann.Annotation.Machine = ""
+
+		// Make a map of CIDR -> Annotation.
+		// Verify that the CIDRs are valid by trying to parse them.
+		// If either the IPv4 or IPv6 CIDRs are wrong, the entry is
+		// discarded. The IPv6 CIDR can be empty in some cases.
+		if ann.Network.IPv4 == "" {
+			continue
+		}
+		_, _, err := net.ParseCIDR(ann.Network.IPv4)
+		if err != nil {
+			fmt.Printf("Skipping %s (%s)\n", ann.Network.IPv4, ann.Annotation.Site)
+			continue
+		}
+
+		// Check the IPv6 CIDR only if not empty.
+		if ann.Network.IPv6 != "" {
+			_, _, err = net.ParseCIDR(ann.Network.IPv6)
+			if err != nil {
+				fmt.Printf("Skipping %s (%s)\n", ann.Network.IPv6, ann.Annotation.Site)
+				continue
+			}
+			sa.networks[ann.Network.IPv6] = ann.Annotation
+		}
+
+		sa.networks[ann.Network.IPv4] = ann.Annotation
+		// TODO: remove.
 		sa.sites[ann.Annotation.Site] = ann.Annotation // Copy out of array.
+	}
+
+	for k, v := range sa.networks {
+		fmt.Printf("%s -> %s\n", k, v.Site)
 	}
 	return nil
 }

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/m-lab/go/osx"
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/uuid-annotator/annotator"
-	uuid "github.com/m-lab/uuid-annotator/annotator"
 )
 
 type badProvider struct {
@@ -55,10 +54,10 @@ func TestBasic(t *testing.T) {
 	site.LoadFrom(ctx, localRawfile, retiredFile)
 
 	var missingServerAnn = annotator.ServerAnnotations{
-		Geo: &uuid.Geolocation{
+		Geo: &annotator.Geolocation{
 			Missing: true,
 		},
-		Network: &uuid.Network{
+		Network: &annotator.Network{
 			Missing: true,
 		},
 	}

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -112,6 +112,11 @@ func TestBasic(t *testing.T) {
 			want: defaultServerAnn,
 		},
 		{
+			name: "success-ipv6",
+			ip:   "2001:5a0:4300::1",
+			want: defaultServerAnn,
+		},
+		{
 			name: "success-retired-site",
 			ip:   "196.201.2.192",
 			want: retiredServerann,
@@ -119,6 +124,11 @@ func TestBasic(t *testing.T) {
 		{
 			name: "missing",
 			ip:   "0.0.0.0",
+			want: missingServerAnn,
+		},
+		{
+			name: "missing-ipv6",
+			ip:   "::1",
 			want: missingServerAnn,
 		},
 	}

--- a/site/testdata/annotations.json
+++ b/site/testdata/annotations.json
@@ -36,38 +36,6 @@
          "Network": {
             "ASName": "TATA COMMUNICATIONS (AMERICA) INC"
          },
-         "Site": "six02"
-      },
-      "Name": "six02",
-      "Network": {
-         "IPv4": "",
-         "IPv6": "2001:5a0:4300::/64"
-      }
-   },
-   {
-      "Annotation": {
-         "Geo": {
-            "City": "New York"
-         },
-         "Network": {
-            "ASName": "TATA COMMUNICATIONS (AMERICA) INC"
-         },
-         "Site": "six01"
-      },
-      "Name": "six01",
-      "Network": {
-         "IPv4": "64.86.148.128/26",
-         "IPv6": ""
-      }
-   },
-   {
-      "Annotation": {
-         "Geo": {
-            "City": "New York"
-         },
-         "Network": {
-            "ASName": "TATA COMMUNICATIONS (AMERICA) INC"
-         },
          "Site": "bad04"
       },
       "Name": "bad04",


### PR DESCRIPTION
This PR changes the site package to be able to annotate IPs belonging to our sites.

A future PR will integrate this into the annotation-service client so IPs are checked against our subnets with the `site.Annotate` function before searching MaxMind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/285)
<!-- Reviewable:end -->
