### PR TITLE
Add server annotation interception to api.GetAnnotations

### DIFF
--- a/api/v2/api-v2.go
+++ b/api/v2/api-v2.go
@@ -11,13 +11,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/m-lab/annotation-service/site"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/m-lab/annotation-service/api"
 	"github.com/m-lab/annotation-service/metrics"
+	"github.com/m-lab/annotation-service/site"
 	"github.com/m-lab/go/logx"
 	uuid "github.com/m-lab/uuid-annotator/annotator"
 )

--- a/api/v2/api-v2.go
+++ b/api/v2/api-v2.go
@@ -209,9 +209,9 @@ func annotateServerIPs(ips []string) ([]string, map[string]*api.Annotations) {
 // GetAnnotations takes a url, and Request, makes remote call, and returns parsed ResponseV2
 // TODO make this unexported once we have migrated all code to use GetAnnotator()
 func GetAnnotations(ctx context.Context, url string, date time.Time, ips []string, info ...string) (*Response, error) {
-	cIPs, sAnno := annotateServerIPs(ips)
+	clientIPs, serverAnn := annotateServerIPs(ips)
 
-	req := NewRequest(date, cIPs)
+	req := NewRequest(date, clientIPs)
 	if len(info) > 0 {
 		req.RequestInfo = info[0]
 	}
@@ -288,8 +288,8 @@ func GetAnnotations(ctx context.Context, url string, date time.Time, ips []strin
 		decodeLogEvery.Println("Decode error:", ErrMoreJSON)
 	}
 	// Append server annotations to results from annotation-service server.
-	for ip, anno := range sAnno {
-		resp.Annotations[ip] = anno
+	for ip, ann := range serverAnn {
+		resp.Annotations[ip] = ann
 	}
 	return &resp, nil
 }

--- a/api/v2/api-v2.go
+++ b/api/v2/api-v2.go
@@ -11,12 +11,15 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/m-lab/annotation-service/site"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/m-lab/annotation-service/api"
 	"github.com/m-lab/annotation-service/metrics"
 	"github.com/m-lab/go/logx"
+	uuid "github.com/m-lab/uuid-annotator/annotator"
 )
 
 /*************************************************************************
@@ -153,10 +156,62 @@ var ErrMoreJSON = errors.New("JSON body not completely consumed")
 
 var decodeLogEvery = logx.NewLogEvery(nil, 30*time.Second)
 
+func convert(s *uuid.ServerAnnotations) *api.Annotations {
+	return &api.Annotations{
+		Geo: &api.GeolocationIP{
+			ContinentCode:       s.Geo.ContinentCode,
+			CountryCode:         s.Geo.CountryCode,
+			CountryCode3:        s.Geo.CountryCode3,
+			CountryName:         s.Geo.CountryName,
+			Region:              s.Geo.Region,
+			Subdivision1ISOCode: s.Geo.Subdivision1ISOCode,
+			Subdivision1Name:    s.Geo.Subdivision1Name,
+			Subdivision2ISOCode: s.Geo.Subdivision2ISOCode,
+			Subdivision2Name:    s.Geo.Subdivision2Name,
+			MetroCode:           s.Geo.MetroCode,
+			City:                s.Geo.City,
+			AreaCode:            s.Geo.AreaCode,
+			PostalCode:          s.Geo.PostalCode,
+			Latitude:            s.Geo.Latitude,
+			Longitude:           s.Geo.Longitude,
+			AccuracyRadiusKm:    s.Geo.AccuracyRadiusKm,
+			Missing:             s.Geo.Missing,
+		},
+		Network: &api.ASData{
+			IPPrefix: "",
+			CIDR:     s.Network.CIDR,
+			ASNumber: s.Network.ASNumber,
+			ASName:   s.Network.ASName,
+			Missing:  s.Network.Missing,
+			// M-Lab Servers only define one System.
+			Systems: []api.System{
+				{ASNs: s.Network.Systems[0].ASNs},
+			},
+		},
+	}
+}
+
+func annotateServerIPs(ips []string) ([]string, map[string]*api.Annotations) {
+	clients := []string{}
+	results := map[string]*api.Annotations{}
+	for _, ip := range ips {
+		s := &uuid.ServerAnnotations{}
+		site.Annotate(ip, s)
+		if (s.Geo == nil && s.Network == nil) || (s.Geo.Missing && s.Network.Missing) {
+			clients = append(clients, ip)
+		} else {
+			results[ip] = convert(s)
+		}
+	}
+	return clients, results
+}
+
 // GetAnnotations takes a url, and Request, makes remote call, and returns parsed ResponseV2
 // TODO make this unexported once we have migrated all code to use GetAnnotator()
 func GetAnnotations(ctx context.Context, url string, date time.Time, ips []string, info ...string) (*Response, error) {
-	req := NewRequest(date, ips)
+	cIPs, sAnno := annotateServerIPs(ips)
+
+	req := NewRequest(date, cIPs)
 	if len(info) > 0 {
 		req.RequestInfo = info[0]
 	}
@@ -231,6 +286,10 @@ func GetAnnotations(ctx context.Context, url string, date time.Time, ips []strin
 	}
 	if decoder.More() {
 		decodeLogEvery.Println("Decode error:", ErrMoreJSON)
+	}
+	// Append server annotations to results from annotation-service server.
+	for ip, anno := range sAnno {
+		resp.Annotations[ip] = anno
 	}
 	return &resp, nil
 }

--- a/api/v2/api-v2_test.go
+++ b/api/v2/api-v2_test.go
@@ -51,16 +51,33 @@ func TestDoRequest(t *testing.T) {
 		AnnotatorDate: time.Date(2018, 12, 5, 0, 0, 0, 0, time.UTC),
 		Annotations: map[string]*types.Annotations{
 			"147.1.2.3": &types.Annotations{
-				Geo:     &types.GeolocationIP{ContinentCode: "NA", CountryCode: "US", CountryName: "United States", Latitude: 37.751, Longitude: -97.822},
+				Geo: &types.GeolocationIP{
+					ContinentCode: "NA",
+					CountryCode:   "US",
+					CountryName:   "United States",
+					Latitude:      37.751,
+					Longitude:     -97.822,
+				},
 				Network: &types.ASData{},
 			},
 			"8.8.8.8": &types.Annotations{
-				Geo:     &types.GeolocationIP{ContinentCode: "NA", CountryCode: "US", CountryName: "United States", Latitude: 37.751, Longitude: -97.822},
+				Geo: &types.GeolocationIP{ContinentCode: "NA",
+					CountryCode: "US",
+					CountryName: "United States",
+					Latitude:    37.751,
+					Longitude:   -97.822,
+				},
 				Network: &types.ASData{},
 			},
 			// Verify current ipv4 sites are annotated correctly.
 			"64.86.148.132": &types.Annotations{
-				Geo: &types.GeolocationIP{ContinentCode: "NA", CountryCode: "US", City: "New York", Latitude: 40.7667, Longitude: -73.8667},
+				Geo: &types.GeolocationIP{
+					ContinentCode: "NA",
+					CountryCode:   "US",
+					City:          "New York",
+					Latitude:      40.7667,
+					Longitude:     -73.8667,
+				},
 				Network: &types.ASData{
 					CIDR:     "64.86.148.128/26",
 					ASNumber: 0x1935,
@@ -72,7 +89,13 @@ func TestDoRequest(t *testing.T) {
 			},
 			// Verify current ipv6 sites are annotated correctly.
 			"2001:5a0:4300::132": &types.Annotations{
-				Geo: &types.GeolocationIP{ContinentCode: "NA", CountryCode: "US", City: "New York", Latitude: 40.7667, Longitude: -73.8667},
+				Geo: &types.GeolocationIP{
+					ContinentCode: "NA",
+					CountryCode:   "US",
+					City:          "New York",
+					Latitude:      40.7667,
+					Longitude:     -73.8667,
+				},
 				Network: &types.ASData{
 					CIDR:     "2001:5a0:4300::/64",
 					ASNumber: 0x1935,
@@ -84,7 +107,12 @@ func TestDoRequest(t *testing.T) {
 			},
 			// Verify that retired sites are annotated correctly.
 			"196.201.2.198": &types.Annotations{
-				Geo: &types.GeolocationIP{ContinentCode: "AF", CountryCode: "GH", City: "Accra", Latitude: 5.606, Longitude: -0.1681},
+				Geo: &types.GeolocationIP{ContinentCode: "AF",
+					CountryCode: "GH",
+					City:        "Accra",
+					Latitude:    5.606,
+					Longitude:   -0.1681,
+				},
 				Network: &types.ASData{
 					CIDR:     "196.201.2.192/26",
 					ASNumber: 0x7915,

--- a/api/v2/api-v2_test.go
+++ b/api/v2/api-v2_test.go
@@ -2,17 +2,21 @@ package api_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-test/deep"
+	types "github.com/m-lab/annotation-service/api"
 	"github.com/m-lab/annotation-service/api/v2"
+	"github.com/m-lab/annotation-service/site"
+	"github.com/m-lab/go/content"
+	"github.com/m-lab/go/rtx"
 )
 
 func init() {
@@ -20,8 +24,52 @@ func init() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 }
 
+var (
+	localRawfile content.Provider
+	retiredFile  content.Provider
+)
+
+func setUp() {
+	u, err := url.Parse("file:testdata/annotations.json")
+	rtx.Must(err, "Could not parse URL")
+	localRawfile, err = content.FromURL(context.Background(), u)
+	rtx.Must(err, "Could not create content.Provider")
+
+	u, err = url.Parse("file:testdata/retired-annotations.json")
+	rtx.Must(err, "Could not parse URL")
+	retiredFile, err = content.FromURL(context.Background(), u)
+	rtx.Must(err, "Could not create content.Provider")
+}
+
 func TestDoRequest(t *testing.T) {
+	setUp()
+	ctx := context.Background()
+	site.LoadFrom(ctx, localRawfile, retiredFile)
+
 	expectedJson := `{"AnnotatorDate":"2018-12-05T00:00:00Z","Annotations":{"147.1.2.3":{"Geo":{"continent_code":"NA","country_code":"US","country_name":"United States","latitude":37.751,"longitude":-97.822},"Network":{}},"8.8.8.8":{"Geo":{"continent_code":"NA","country_code":"US","country_name":"United States","latitude":37.751,"longitude":-97.822},"Network":{}}}}`
+	expectedResp := api.Response{
+		AnnotatorDate: time.Date(2018, 12, 5, 0, 0, 0, 0, time.UTC),
+		Annotations: map[string]*types.Annotations{
+			"147.1.2.3": &types.Annotations{
+				Geo:     &types.GeolocationIP{ContinentCode: "NA", CountryCode: "US", CountryName: "United States", Latitude: 37.751, Longitude: -97.822},
+				Network: &types.ASData{},
+			},
+			"8.8.8.8": &types.Annotations{
+				Geo:     &types.GeolocationIP{ContinentCode: "NA", CountryCode: "US", CountryName: "United States", Latitude: 37.751, Longitude: -97.822},
+				Network: &types.ASData{},
+			},
+			"64.86.148.132": &types.Annotations{
+				Geo: &types.GeolocationIP{ContinentCode: "NA", CountryCode: "US", City: "New York", Latitude: 40.7667, Longitude: -73.8667},
+				Network: &types.ASData{
+					ASNumber: 0x1935,
+					ASName:   "TATA COMMUNICATIONS (AMERICA) INC",
+					Systems: []types.System{
+						{ASNs: []uint32{0x1935}},
+					},
+				},
+			},
+		},
+	}
 	callCount := 0
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +83,7 @@ func TestDoRequest(t *testing.T) {
 	url := ts.URL
 
 	//url = "https://annotator-dot-mlab-sandbox.appspot.com/batch_annotate"
-	ips := []string{"8.8.8.8", "147.1.2.3"}
+	ips := []string{"8.8.8.8", "147.1.2.3", "64.86.148.132"}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	_, err := api.GetAnnotations(ctx, url, time.Now(), ips, "reqInfo")
@@ -52,13 +100,8 @@ func TestDoRequest(t *testing.T) {
 	if callCount != 4 {
 		t.Error("Should have been two calls to server.")
 	}
-	expectedResponse := api.Response{}
-	err = json.Unmarshal([]byte(expectedJson), &expectedResponse)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	if diff := deep.Equal(expectedResponse, *resp); diff != nil {
+	if diff := deep.Equal(expectedResp, *resp); diff != nil {
 		t.Error(diff)
 	}
 }

--- a/api/v2/api-v2_test.go
+++ b/api/v2/api-v2_test.go
@@ -58,13 +58,39 @@ func TestDoRequest(t *testing.T) {
 				Geo:     &types.GeolocationIP{ContinentCode: "NA", CountryCode: "US", CountryName: "United States", Latitude: 37.751, Longitude: -97.822},
 				Network: &types.ASData{},
 			},
+			// Verify current ipv4 sites are annotated correctly.
 			"64.86.148.132": &types.Annotations{
 				Geo: &types.GeolocationIP{ContinentCode: "NA", CountryCode: "US", City: "New York", Latitude: 40.7667, Longitude: -73.8667},
 				Network: &types.ASData{
+					CIDR:     "64.86.148.128/26",
 					ASNumber: 0x1935,
 					ASName:   "TATA COMMUNICATIONS (AMERICA) INC",
 					Systems: []types.System{
 						{ASNs: []uint32{0x1935}},
+					},
+				},
+			},
+			// Verify current ipv6 sites are annotated correctly.
+			"2001:5a0:4300::132": &types.Annotations{
+				Geo: &types.GeolocationIP{ContinentCode: "NA", CountryCode: "US", City: "New York", Latitude: 40.7667, Longitude: -73.8667},
+				Network: &types.ASData{
+					CIDR:     "2001:5a0:4300::/64",
+					ASNumber: 0x1935,
+					ASName:   "TATA COMMUNICATIONS (AMERICA) INC",
+					Systems: []types.System{
+						{ASNs: []uint32{0x1935}},
+					},
+				},
+			},
+			// Verify that retired sites are annotated correctly.
+			"196.201.2.198": &types.Annotations{
+				Geo: &types.GeolocationIP{ContinentCode: "AF", CountryCode: "GH", City: "Accra", Latitude: 5.606, Longitude: -0.1681},
+				Network: &types.ASData{
+					CIDR:     "196.201.2.192/26",
+					ASNumber: 0x7915,
+					ASName:   "Ghana Internet Exchange Association",
+					Systems: []types.System{
+						{ASNs: []uint32{0x7915}},
 					},
 				},
 			},
@@ -83,7 +109,7 @@ func TestDoRequest(t *testing.T) {
 	url := ts.URL
 
 	//url = "https://annotator-dot-mlab-sandbox.appspot.com/batch_annotate"
-	ips := []string{"8.8.8.8", "147.1.2.3", "64.86.148.132"}
+	ips := []string{"8.8.8.8", "147.1.2.3", "64.86.148.132", "2001:5a0:4300::132", "196.201.2.198"}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	_, err := api.GetAnnotations(ctx, url, time.Now(), ips, "reqInfo")

--- a/api/v2/testdata/annotations.json
+++ b/api/v2/testdata/annotations.json
@@ -1,0 +1,31 @@
+[
+   {
+      "Annotation": {
+         "Geo": {
+            "City": "New York",
+            "ContinentCode": "NA",
+            "CountryCode": "US",
+            "Latitude": 40.7667,
+            "Longitude": -73.8667,
+            "State": "NY"
+         },
+         "Network": {
+            "ASName": "TATA COMMUNICATIONS (AMERICA) INC",
+            "ASNumber": 6453,
+            "Systems": [
+               {
+                  "ASNs": [
+                     6453
+                  ]
+               }
+            ]
+         },
+         "Site": "lga03"
+      },
+      "Name": "lga03",
+      "Network": {
+         "IPv4": "64.86.148.128/26",
+         "IPv6": "2001:5a0:4300::/64"
+      }
+   }
+]

--- a/api/v2/testdata/retired-annotations.json
+++ b/api/v2/testdata/retired-annotations.json
@@ -1,0 +1,60 @@
+[
+    {
+       "Annotation": {
+          "Geo": {
+             "City": "Accra",
+             "ContinentCode": "AF",
+             "CountryCode": "GH",
+             "Latitude": 5.606,
+             "Longitude": -0.1681,
+             "State": ""
+          },
+          "Network": {
+             "ASName": "Ghana Internet Exchange Association",
+             "ASNumber": 30997,
+             "Systems": [
+                {
+                   "ASNs": [
+                      30997
+                   ]
+                }
+             ]
+          },
+          "Site": "acc01"
+       },
+       "Name": "acc01",
+       "Network": {
+          "IPv4": "196.201.2.192/26",
+          "IPv6": ""
+       }
+    },
+    {
+        "Annotation": {
+           "Geo": {
+              "City": "Accra",
+              "ContinentCode": "AF",
+              "CountryCode": "GH",
+              "Latitude": 5.606,
+              "Longitude": -0.1681,
+              "State": ""
+           },
+           "Network": {
+              "ASName": "Ghana Internet Exchange Association",
+              "ASNumber": 30997,
+              "Systems": [
+                 {
+                    "ASNs": [
+                       30997
+                    ]
+                 }
+              ]
+           },
+           "Site": "acc02"
+        },
+        "Name": "acc02",
+        "Network": {
+           "IPv4": "196.49.14.192/26",
+           "IPv6": ""
+        }
+     }
+]

--- a/site/site.go
+++ b/site/site.go
@@ -45,7 +45,7 @@ func LoadFrom(ctx context.Context, js content.Provider, retiredJS content.Provid
 		networks:              make(map[string]uuid.ServerAnnotations, 400),
 	}
 	err := globalAnnotator.load(ctx)
-	log.Println(len(globalAnnotator.sites), "sites loaded")
+	log.Println(len(globalAnnotator.networks), "sites loaded")
 	return err
 }
 
@@ -87,7 +87,6 @@ type annotator struct {
 	siteinfoRetiredSource content.Provider
 	// Each site has a single ServerAnnotations struct, which
 	// is later customized for each machine.
-	sites    map[string]uuid.ServerAnnotations
 	networks map[string]uuid.ServerAnnotations
 }
 

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -194,3 +194,18 @@ func TestCorrupt(t *testing.T) {
 		t.Error("Expected load error")
 	}
 }
+
+func TestMustReload(t *testing.T) {
+	flag.Set("siteinfo.url", "file:testdata/annotations.json")
+	flag.Set("siteinfo.retired-url", "file:testdata/retired-annotations.json")
+	t.Run("success", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		complete := make(chan struct{})
+		go func() {
+			site.MustReload(ctx)
+			close(complete)
+		}()
+		<-complete // wait until context times out.
+	})
+}


### PR DESCRIPTION
This change adds new behavior to the `api.GetAnnotations` annotation-service client api. The call attempts to annotate all given IPs using static and locally loaded ServerAnnotations. All successful IPs are accepted to be Server IPs, and removed from the set of remaining IPs which are accepted to be Client IPs. All remaining Client IPs are sent to the annotation-service as before. Finally, before returning the response, the server annotations originally discovered are appended. So, server annotations are only returned if the client request is also successful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/286)
<!-- Reviewable:end -->
