### PR TITLE
Set default siteinfo URLs and update loaded log message

### DIFF
--- a/site/site.go
+++ b/site/site.go
@@ -46,7 +46,7 @@ func LoadFrom(ctx context.Context, js content.Provider, retiredJS content.Provid
 		networks:              make(map[string]uuid.ServerAnnotations, 400),
 	}
 	err := globalAnnotator.load(ctx)
-	log.Println(len(globalAnnotator.networks), "sites loaded")
+	log.Println(globalAnnotator.sites, "sites loaded with", len(globalAnnotator.networks), "networks")
 	return err
 }
 
@@ -100,9 +100,10 @@ func Load(timeout time.Duration) error {
 type annotator struct {
 	siteinfoSource        content.Provider
 	siteinfoRetiredSource content.Provider
-	// Each site has a single ServerAnnotations struct, which
-	// is later customized for each machine.
+	// Each site network (v4 or v6) has a single ServerAnnotations struct,
+	// which is later customized for each machine.
 	networks map[string]uuid.ServerAnnotations
+	sites    int
 }
 
 // missing is used if annotation is requested for a non-existant server.
@@ -207,6 +208,7 @@ func (sa *annotator) load(ctx context.Context) error {
 		}
 
 		sa.networks[ann.Network.IPv4] = ann.Annotation
+		sa.sites++
 	}
 
 	return nil

--- a/site/site.go
+++ b/site/site.go
@@ -20,8 +20,8 @@ import (
 var (
 	// For example of how siteinfo is loaded on production servers, see
 	// https://github.com/m-lab/k8s-support/blob/ff5b53faef7828d11d45c2a4f27d53077ddd080c/k8s/daemonsets/templates.jsonnet#L350
-	siteinfo        = flagx.URL{}
-	siteinfoRetired = flagx.URL{}
+	siteinfo        = flagx.MustNewURL("https://siteinfo.mlab-oti.measurementlab.net/v1/sites/annotations.json")
+	siteinfoRetired = flagx.MustNewURL("https://siteinfo.mlab-oti.measurementlab.net/v1/retired/annotations.json")
 	globalAnnotator *annotator
 )
 


### PR DESCRIPTION
When beginning to integrate siteinfo reloading into the `etl_worker` I discovered two things:

* the log message from sites.go is confusing b/c it was reporting the total number of networks as sites.
* the empty siteinfo URLs caused a segfault when trying to read them during loading.

This change adds site counting during load and updates the log message to report on site count and network counts.
This change also adds default values for the siteinfo URLs using the production URLs. This is almost always the value we want, and the site package unit tests override these values already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/288)
<!-- Reviewable:end -->
