### PR TITLE
Fix: do not assign to nil resp.Annotations map

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
  # Run all tests and gather and submit coverage information.
  - GCLOUD_PROJECT=mlab-testing go test -v -coverpkg=./... -coverprofile=coverage.cov ./...
 
- - $HOME/gopath/bin/goveralls -coverprofile=coverage.cov -service=travis-ci || :
+ - $HOME/gopath/bin/goveralls -coverprofile=coverage.cov -service=travis-ci || true
  # Run benchmarks
  - go test -bench . ./geolite2v2/...
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,7 @@ deploy:
  # branch to sandbox for pre-review testing.
  - provider: script
    script:
+    gcloud config set app/cloud_build_timeout 1200 &&
     $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-sandbox /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR annotator.yaml
    skip_cleanup: true
    on:
@@ -107,6 +108,7 @@ deploy:
  # STAGING: Should trigger AFTER code review and commit to master branch.
  - provider: script
    script:
+    gcloud config set app/cloud_build_timeout 1200 &&
     $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-staging /tmp/mlab-staging.json $TRAVIS_BUILD_DIR annotator.yaml
    skip_cleanup: true
    on:
@@ -117,6 +119,7 @@ deploy:
  # when tagged with prod-*.
  - provider: script
    script:
+    gcloud config set app/cloud_build_timeout 1200 &&
     $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-oti /tmp/mlab-oti.json $TRAVIS_BUILD_DIR annotator.yaml
    skip_cleanup: true
    on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
  # Run all tests and gather and submit coverage information.
  - GCLOUD_PROJECT=mlab-testing go test -v -coverpkg=./... -coverprofile=coverage.cov ./...
 
- - $HOME/gopath/bin/goveralls -coverprofile=coverage.cov -service=travis-ci
+ - $HOME/gopath/bin/goveralls -coverprofile=coverage.cov -service=travis-ci || :
  # Run benchmarks
  - go test -bench . ./geolite2v2/...
 

--- a/api/v2/api-v2.go
+++ b/api/v2/api-v2.go
@@ -202,7 +202,10 @@ func annotateServerIPs(ips []string) ([]string, map[string]*api.Annotations) {
 			results[ip] = convert(s)
 		}
 	}
-	return clients, results
+	if len(results) > 0 {
+		return clients, results
+	}
+	return clients, nil
 }
 
 // GetAnnotations takes a url, and Request, makes remote call, and returns parsed ResponseV2
@@ -287,8 +290,12 @@ func GetAnnotations(ctx context.Context, url string, date time.Time, ips []strin
 		decodeLogEvery.Println("Decode error:", ErrMoreJSON)
 	}
 	// Append server annotations to results from annotation-service server.
-	for ip, ann := range serverAnn {
-		resp.Annotations[ip] = ann
+	if resp.Annotations == nil {
+		resp.Annotations = serverAnn
+	} else {
+		for ip, ann := range serverAnn {
+			resp.Annotations[ip] = ann
+		}
 	}
 	return &resp, nil
 }


### PR DESCRIPTION
Under some conditions the annotation service returns a successful response with an empty (nil) value in `Annotations`. Some caller code handles this case (https://github.com/m-lab/etl/blob/master/parser/base.go#L100-L101) but there is not evidence of this happening before the change to use siteinfo server annotations. So, I suspect that fewer IPs are sent to the annotation-service now which may have introduced this new error case.

This change guarantees that the `resp.Annotations` is only updated if it is not nil, and to preserve the nil value if both the annotation service and server IPs return no results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/289)
<!-- Reviewable:end -->
