### PR TITLE
Make server annotation convert safe

### DIFF
--- a/api/v2/api-v2.go
+++ b/api/v2/api-v2.go
@@ -196,7 +196,7 @@ func convert(s *uuid.ServerAnnotations) *api.Annotations {
 // API and should be retired with the annotation-service once the annotation
 // export processes are complete.
 func ConvertAnnotationsToServerAnnotations(a *api.Annotations) *uuid.ServerAnnotations {
-	return &uuid.ServerAnnotations{
+	s := &uuid.ServerAnnotations{
 		Geo: &uuid.Geolocation{
 			ContinentCode:       a.Geo.ContinentCode,
 			CountryCode:         a.Geo.CountryCode,
@@ -221,12 +221,15 @@ func ConvertAnnotationsToServerAnnotations(a *api.Annotations) *uuid.ServerAnnot
 			ASNumber: a.Network.ASNumber,
 			ASName:   a.Network.ASName,
 			Missing:  a.Network.Missing,
-			// M-Lab Servers only define one System.
-			Systems: []uuid.System{
-				{ASNs: a.Network.Systems[0].ASNs},
-			},
 		},
 	}
+	if len(a.Network.Systems) > 0 {
+		// M-Lab Servers only define one System.
+		s.Network.Systems = []uuid.System{
+			{ASNs: a.Network.Systems[0].ASNs},
+		}
+	}
+	return s
 }
 
 // ConvertAnnotationsToClientAnnotations accepts an annotation from the v2 API

--- a/api/v2/api-v2_test.go
+++ b/api/v2/api-v2_test.go
@@ -217,6 +217,14 @@ func TestConvertAnnotationsToServerAnnotations(t *testing.T) {
 			},
 		},
 	}
+	empty := &types.Annotations{
+		Geo: &types.GeolocationIP{
+			Missing: true,
+		},
+		Network: &types.ASData{
+			Missing: true,
+		},
+	}
 	expectedServer := &uuid.ServerAnnotations{
 		// NOTE: the Site and Machine fields will not be specified.
 		Geo: &uuid.Geolocation{
@@ -239,6 +247,14 @@ func TestConvertAnnotationsToServerAnnotations(t *testing.T) {
 			Systems: []uuid.System{
 				{ASNs: []uint32{10}},
 			},
+		},
+	}
+	expectedEmpty := &uuid.ServerAnnotations{
+		Geo: &uuid.Geolocation{
+			Missing: true,
+		},
+		Network: &uuid.Network{
+			Missing: true,
 		},
 	}
 	expectedClient := &uuid.ClientAnnotations{
@@ -268,6 +284,10 @@ func TestConvertAnnotationsToServerAnnotations(t *testing.T) {
 	gs := api.ConvertAnnotationsToServerAnnotations(a)
 	if !reflect.DeepEqual(gs, expectedServer) {
 		t.Errorf("ConvertAnnotationsToServerAnnotations() = %v, want %v", gs, expectedServer)
+	}
+	gempty := api.ConvertAnnotationsToServerAnnotations(empty)
+	if !reflect.DeepEqual(gempty, expectedEmpty) {
+		t.Errorf("ConvertAnnotationsToServerAnnotations() = %v, want %v", gempty, expectedEmpty)
 	}
 
 	gc := api.ConvertAnnotationsToClientAnnotations(a)


### PR DESCRIPTION
When used with a known server IP, the server annotation conversion will work as intended. When used with an unknown server IP, the resulting annotation may have `.Network{Missing: true}` with an empty `Systems` list, which results in a panic. This change makes the server annotation conversion safe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/291)
<!-- Reviewable:end -->
