### PR TITLE
Increase RAM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,10 +78,6 @@ script:
  # Run benchmarks
  - go test -bench . ./geolite2v2/...
 
- # Check dependent projects
- - go get -t github.com/m-lab/etl/...
- - go vet github.com/m-lab/etl/...
-
  # Build and prepare for deployment
  - go build
  - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh

--- a/annotator.yaml
+++ b/annotator.yaml
@@ -9,11 +9,11 @@ service: annotator
 
 # TODO(dev): adjust CPU and memory based on actual requirements.
 resources:
-  cpu: 40
+  cpu: 44
   # Instances support between [(cpu * 0.9) - 0.4, (cpu * 6.5) - 0.4]
   # Actual memory available is exposed via GAE_MEMORY_MB environment variable.
   # Service now loads ALL datasets, so it needs quite a lot of memory.
-  memory_gb: 259
+  memory_gb: 280
 
   # Annotation service uses disk for loading legacy Geolite datasets.  It now loads many
   # concurrently, so needs a lot of disk space.


### PR DESCRIPTION
Due to the current design of the annotation-service, it attempts to load all historical annotation databases into memory simultaneously. Since the tcpinfo datatype is still using the annotation service and new data is collected daily, the annotation service still needs new annotation datasets. However, it has recently reached the limit of the current configuration, causing the service to fail in production. This change increases the CPU and RAM size (a function of CPU count) an additional 20GB. This should provide time to migrate the tcpinfo datatype to the v2 data pipeline and suspend the annotation-service before the RAM is used again.

The service has been running with a single instance since Feb 28th, and now cannot keep one instance running.

<img width="927" alt="Screen Shot 2022-03-08 at 11 09 10 AM" src="https://user-images.githubusercontent.com/1085316/157277623-e9590e03-210f-475b-86c9-1eb843421f2d.png">

The annotation service requires more RAM.

![more-ram](https://user-images.githubusercontent.com/1085316/157276523-5abf4308-58cb-4097-b858-2365c3bc7a33.jpeg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/293)
<!-- Reviewable:end -->
