### PR TITLE
Add travis-wait-improved during deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,10 @@ script:
  - go build
  - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
 
+before_deploy:
+ # See: https://github.com/cisagov/travis-wait-improved
+ - pip install travis-wait-improved
+
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
 # after a merge with matching "on:" conditions.
 deploy:
@@ -93,7 +97,7 @@ deploy:
  - provider: script
    script:
     gcloud config set app/cloud_build_timeout 1200 &&
-    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-sandbox /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR annotator.yaml
+    travis-wait-improved --timeout 30m $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-sandbox /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR annotator.yaml
    skip_cleanup: true
    on:
     repo: m-lab/annotation-service
@@ -105,7 +109,7 @@ deploy:
  - provider: script
    script:
     gcloud config set app/cloud_build_timeout 1200 &&
-    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-staging /tmp/mlab-staging.json $TRAVIS_BUILD_DIR annotator.yaml
+    travis-wait-improved --timeout 30m $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-staging /tmp/mlab-staging.json $TRAVIS_BUILD_DIR annotator.yaml
    skip_cleanup: true
    on:
     repo: m-lab/annotation-service
@@ -116,7 +120,7 @@ deploy:
  - provider: script
    script:
     gcloud config set app/cloud_build_timeout 1200 &&
-    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-oti /tmp/mlab-oti.json $TRAVIS_BUILD_DIR annotator.yaml
+    travis-wait-improved --timeout 30m $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-oti /tmp/mlab-oti.json $TRAVIS_BUILD_DIR annotator.yaml
    skip_cleanup: true
    on:
     repo: m-lab/annotation-service


### PR DESCRIPTION
The annotation service includes a dependency on `google.golang.org/api ` which must be downloaded twice with the current configuration (once for testing by travis, once for deployment by AppEngine). The total package size is currently around ~719MB (it seems to grow over time). The annotation service has failed four times during the deployment phase while downloading this package. This change introduces a mechanism to wait.

The mechanism provided by travis to work around [slow operations `travis_wait`](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received) is not available during deployment steps. 

A third-party package that solves this problem `travis-wait-improved` provides a tool with the same effect (prevent timeouts) and usable from deployment steps. https://github.com/cisagov/travis-wait-improved

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/annotation-service/294)
<!-- Reviewable:end -->
